### PR TITLE
Adds AClaimsClass parameter to TJOSE.Verify

### DIFF
--- a/Source/Common/JOSE.Hashing.HMAC.pas
+++ b/Source/Common/JOSE.Hashing.HMAC.pas
@@ -55,7 +55,7 @@ begin
   LSigner := nil;
 
   if not IdSSLOpenSSL.LoadOpenSSLLibrary then
-    raise Exception.Create('Error Message');
+    raise Exception.Create('Cannot load OpenSSL Library.');
 
   case AAlg of
     SHA256: LSigner := TIdHMACSHA256.Create;

--- a/Source/JOSE/JOSE.Core.Builder.pas
+++ b/Source/JOSE/JOSE.Core.Builder.pas
@@ -41,10 +41,10 @@ uses
 type
   TJOSE = class
   private
-    class function DeserialzeVerify(AKey: TJWK; ACompactToken: TSuperBytes; AVerify: Boolean): TJWT;
+    class function DeserialzeVerify(AKey: TJWK; ACompactToken: TSuperBytes; AVerify: Boolean; AClaimsClass: TJWTClaimsClass): TJWT;
   public
     class function Sign(AKey: TJWK; AAlg: TJWAEnum; AToken: TJWT): TSuperBytes;
-    class function Verify(AKey: TJWK; ACompactToken: TSuperBytes): TJWT;
+    class function Verify(AKey: TJWK; ACompactToken: TSuperBytes; AClaimsClass: TJWTClaimsClass = nil): TJWT;
 
     class function SerializeCompact(AKey: TJWK; AAlg: TJWAEnum; AToken: TJWT): TSuperBytes;
     class function DeserializeCompact(const ACompactToken: TSuperBytes): TJWT;
@@ -63,10 +63,11 @@ uses
 
 class function TJOSE.DeserializeCompact(const ACompactToken: TSuperBytes): TJWT;
 begin
-  Result := DeserialzeVerify(nil, ACompactToken, True);
+  Result := DeserialzeVerify(nil, ACompactToken, True, TJWTClaims);
 end;
 
-class function TJOSE.DeserialzeVerify(AKey: TJWK; ACompactToken: TSuperBytes; AVerify: Boolean): TJWT;
+class function TJOSE.DeserialzeVerify(AKey: TJWK; ACompactToken: TSuperBytes; AVerify: Boolean; AClaimsClass:
+    TJWTClaimsClass): TJWT;
 var
   LRes: TStringDynArray;
   LSigner: TJWS;
@@ -77,7 +78,7 @@ begin
   case Length(LRes) of
     3:
     begin
-      Result := TJWT.Create(TJWTClaims);
+      Result := TJWT.Create(AClaimsClass);
       try
         LSigner := TJWS.Create(Result);
         try
@@ -142,9 +143,12 @@ begin
   end;
 end;
 
-class function TJOSE.Verify(AKey: TJWK; ACompactToken: TSuperBytes): TJWT;
+class function TJOSE.Verify(AKey: TJWK; ACompactToken: TSuperBytes; AClaimsClass: TJWTClaimsClass): TJWT;
 begin
-  Result := DeserialzeVerify(AKey, ACompactToken, True);
+  if not Assigned(AClaimsClass) then
+    AClaimsClass := TJWTClaims;
+
+  Result := DeserialzeVerify(AKey, ACompactToken, True, AClaimsClass);
 end;
 
 end.

--- a/Source/JOSE/JOSE.Core.JWS.pas
+++ b/Source/JOSE/JOSE.Core.JWS.pas
@@ -114,7 +114,7 @@ var
   LRes: TStringDynArray;
 begin
   LRes := SplitString(Value, PART_SEPARATOR);
-  if Length(LRes) = 3 then
+  if Length(LRes) = COMPACT_PARTS then
   begin
     FParts[0] := LRes[0];
     FParts[1] := LRes[1];

--- a/Source/JOSE/JOSE.Core.JWT.pas
+++ b/Source/JOSE/JOSE.Core.JWT.pas
@@ -148,8 +148,8 @@ begin
 end;
 
 procedure TJWTClaims.CheckRegisteredClaims(AOptions: TClaimVerifications = []);
-var
-  LOption: TClaimVerification;
+//var
+//  LOption: TClaimVerification;
 begin
 {
   for LOption in AOptions do


### PR DESCRIPTION
This allows instantiating a custom claim class when verifying the token:
```
Token := TJOSE.Verify(Key, Value, TMyClaims);
if Assigned(Token) and Token.Verified then
begin
  Claims := Token.Claims as TMyClaims;
  Writeln(Claims.MyCustomClaim);
end
```

I don't know if this is the best approach for doing it, or if there is another way, but I couldn't find how to read the data from my custom claims after verifying the token, so I made this changes which are the simplest way I found for doing it without breaking any compatibility.

Is there another way for doing it or a better way (maybe with generics to avoid the explicit cast)?

Thanks.