### PR TITLE
Wrong Base64 encoding/decoding when using Delphi XE6

### DIFF
--- a/Source/Common/JOSE.Encoding.Base64.pas
+++ b/Source/Common/JOSE.Encoding.Base64.pas
@@ -164,7 +164,7 @@ begin
   {$IF CompilerVersion >= 28}
   Result := TNetEncoding.Base64.Decode(ASource.AsBytes);
   {$ELSE}
-  Result := EncodeBase64(ASource.AsBytes);
+  Result := DecodeBase64(ASource.AsString);
   {$ENDIF}
 end;
 
@@ -173,7 +173,7 @@ begin
   {$IF CompilerVersion >= 28}
   Result := TNetEncoding.Base64.Encode(ASource.AsBytes);
   {$ELSE}
-  Result := DecodeBase64(ASource.AsString);
+  Result := EncodeBase64(ASource.AsBytes);
   {$ENDIF}
 end;
 


### PR DESCRIPTION
Specific XE6 code was wrong for encode/decode base64