### PR TITLE
Support RSA signing

### DIFF
--- a/Source/Common/JOSE.Cryptography.RSA.pas
+++ b/Source/Common/JOSE.Cryptography.RSA.pas
@@ -24,6 +24,228 @@ unit JOSE.Cryptography.RSA;
 
 interface
 
+uses
+  System.SysUtils,
+  IdGlobal,
+  IdCTypes,
+  IdSSLOpenSSLHeaders,
+  JOSE.Encoding.Base64;
+
+
+type
+  TRSAAlgorithm = (RS256, RS384, RS512);
+  TRSAAlgorithmHelper = record helper for TRSAAlgorithm
+    procedure FromString(const AValue: string);
+    function ToString: string;
+  end;
+
+  TRSA = class
+  private
+    class procedure LoadOpenSSL;
+  public
+    class function Sign(const AInput, AKey: TBytes; AAlg: TRSAAlgorithm): TBytes;
+    class function Verify(const AInput, ASignature, AKey: TBytes; AAlg: TRSAAlgorithm): Boolean;
+    class function VerifyPublicKey(const AKey: TBytes): Boolean;
+    class function VerifyPrivateKey(const AKey: TBytes): Boolean;
+  end;
+
 implementation
+
+uses
+  System.AnsiStrings;
+
+// Get OpenSSL error and message text
+function ERR_GetErrorMessage_OpenSSL : String;
+var locErrMsg: array [0..160] of Char;
+begin
+  ERR_error_string( ERR_get_error, @locErrMsg );
+  result := String( System.AnsiStrings.StrPas( PAnsiChar(@locErrMsg) ) );
+end;
+
+{ TRSAAlgorithmHelper }
+
+procedure TRSAAlgorithmHelper.FromString(const AValue: string);
+begin
+  if AValue = 'RS256' then
+    Self := RS256
+  else if AValue = 'RS384' then
+    Self := RS384
+  else if AValue = 'RS512' then
+    Self := RS512
+  else
+    raise Exception.Create('Invalid RSA algorithm type');
+end;
+
+function TRSAAlgorithmHelper.ToString: string;
+begin
+  case Self of
+    RS256: Result := 'RS256';
+    RS384: Result := 'RS384';
+    RS512: Result := 'RS512';
+  end;
+end;
+
+{ TRSA }
+
+class function TRSA.Sign(const AInput, AKey: TBytes;
+  AAlg: TRSAAlgorithm): TBytes;
+var
+  PrivKeyBIO: pBIO;
+  PrivKey: pEVP_PKEY;
+  rsa: pRSA;
+
+  locBIO: pBIO;
+  locCtx: PEVP_MD_CTX;
+  locSHA: PEVP_MD;
+
+  slen: Integer;
+  sig: Pointer;
+begin
+  LoadOpenSSL;
+
+  // Load Private RSA Key into RSA object
+  PrivKeyBIO := BIO_new(BIO_s_mem);
+  try
+    BIO_write(PrivKeyBIO, @AKey[0], Length(AKey));
+    rsa := PEM_read_bio_RSAPrivateKey(PrivKeyBIO, nil, nil, nil);
+    if rsa = nil then
+      raise Exception.Create('[RSA] Unable to load private key: '+ERR_GetErrorMessage_OpenSSL);
+  finally
+    BIO_free(PrivKeyBIO);
+  end;
+
+  // Extract Private key from RSA object
+  PrivKey := EVP_PKEY_new();
+  if EVP_PKEY_set1_RSA(PrivKey, rsa) <> 1 then
+    raise Exception.Create('[RSA] Unable to extract private key: '+ERR_GetErrorMessage_OpenSSL);
+
+  locBio := BIO_new( BIO_f_md );
+  locSHA := nil;
+  try
+    // Create context. Use this strage hack since Indy library has no EVP_MD_CTX_create
+    BIO_get_md_ctx( locBio, @locCtx );
+
+    case AAlg of
+      RS256: locSHA := EVP_sha256();
+      RS384: locSHA := EVP_sha384();
+      RS512: locSHA := EVP_sha512();
+    end;
+
+    if EVP_DigestSignInit( locCtx, NIL, locSHA, NIL, PrivKey ) <> 1 then
+      raise Exception.Create('[RSA] Unable to init context: '+ERR_GetErrorMessage_OpenSSL);
+    if EVP_DigestSignUpdate( locCtx, @AInput[0], Length(AInput) ) <> 1 then
+      raise Exception.Create('[RSA] Unable to update context with payload: '+ERR_GetErrorMessage_OpenSSL);
+    // Get signature, first read signature len
+    EVP_DigestSignFinal( locCtx, nil, @slen );
+    sig := OPENSSL_malloc(slen);
+    try
+      EVP_DigestSignFinal( locCtx, sig, @slen );
+      setLength(Result, slen);
+      move(sig^, Result[0], slen);
+    finally
+      CRYPTO_free(sig);
+    end;
+  finally
+    BIO_free( locBio );
+  end;
+end;
+
+class function TRSA.Verify(const AInput, ASignature, AKey: TBytes;
+  AAlg: TRSAAlgorithm): Boolean;
+var
+  PubKeyBIO: pBIO;
+  PubKey: pEVP_PKEY;
+  rsa: pRSA;
+
+  locBIO: pBIO;
+  locCtx: PEVP_MD_CTX;
+  locSHA: PEVP_MD;
+begin
+  LoadOpenSSL;
+
+  Result := False;
+
+  // Load Public RSA Key into RSA object
+  PubKeyBIO := BIO_new(BIO_s_mem);
+  try
+    BIO_write(PubKeyBIO, @AKey[0], Length(AKey));
+    rsa := PEM_read_bio_RSAPublicKey(PubKeyBIO, nil, nil, nil);
+    if rsa = nil then
+      raise Exception.Create('[RSA] Unable to load public key: '+ERR_GetErrorMessage_OpenSSL);
+  finally
+    BIO_free(PubKeyBIO);
+  end;
+
+  // Extract Public key from RSA object
+  PubKey := EVP_PKEY_new();
+  if EVP_PKEY_set1_RSA(PubKey,rsa) <> 1 then
+    raise Exception.Create('[RSA] Unable to extract public key: '+ERR_GetErrorMessage_OpenSSL);
+
+  locBio := BIO_new( BIO_f_md );
+  locSHA := nil;
+  try
+    // Create context. Use this strage hack since Indy library has no EVP_MD_CTX_create
+    BIO_get_md_ctx( locBio, @locCtx );
+
+    case AAlg of
+      RS256: locSHA := EVP_sha256();
+      RS384: locSHA := EVP_sha384();
+      RS512: locSHA := EVP_sha512();
+    end;
+
+    if EVP_DigestVerifyInit( locCtx, NIL, locSHA, NIL, PubKey ) <> 1 then
+      raise Exception.Create('[RSA] Unable to init context: '+ERR_GetErrorMessage_OpenSSL);
+    if EVP_DigestVerifyUpdate( locCtx, @AInput[0], Length(AInput) ) <> 1 then
+      raise Exception.Create('[RSA] Unable to update context with payload: '+ERR_GetErrorMessage_OpenSSL);
+    result := ( EVP_DigestVerifyFinal( locCtx, PAnsiChar(@ASignature[0]), length(ASignature) ) = 1 );
+  finally
+    BIO_free( locBio );
+  end;
+end;
+
+class function TRSA.VerifyPrivateKey(const AKey: TBytes): Boolean;
+var
+  PubKeyBIO: pBIO;
+  rsa: pRSA;
+begin
+  LoadOpenSSL;
+
+  // Load Public RSA Key
+  PubKeyBIO := BIO_new(BIO_s_mem);
+  try
+    BIO_write(PubKeyBIO, @AKey[0], Length(AKey));
+    rsa := PEM_read_bio_RSAPrivateKey(PubKeyBIO, nil, nil, nil);
+    Result := (rsa <> nil);
+  finally
+    BIO_free(PubKeyBIO);
+  end;
+end;
+
+class function TRSA.VerifyPublicKey(const AKey: TBytes): Boolean;
+var
+  PubKeyBIO: pBIO;
+  rsa: pRSA;
+begin
+  LoadOpenSSL;
+
+  // Load Public RSA Key
+  PubKeyBIO := BIO_new(BIO_s_mem);
+  try
+    BIO_write(PubKeyBIO, @AKey[0], Length(AKey));
+    rsa := PEM_read_bio_RSAPublicKey(PubKeyBIO, nil, nil, nil);
+    Result := (rsa <> nil);
+  finally
+    BIO_free(PubKeyBIO);
+  end;
+end;
+
+class procedure TRSA.LoadOpenSSL;
+begin
+  if not IdSSLOpenSSLHeaders.Load then
+    raise Exception.Create('[RSA] Unable to load OpenSSL DLLs');
+
+  if @EVP_DigestVerifyInit = nil then
+    raise Exception.Create('[RSA] Please, use OpenSSL 1.0.0. or newer!');
+end;
 
 end.

--- a/Source/Common/JOSE.Signing.RSA.pas
+++ b/Source/Common/JOSE.Signing.RSA.pas
@@ -20,7 +20,7 @@
 {                                                                              }
 {******************************************************************************}
 
-unit JOSE.Cryptography.RSA;
+unit JOSE.Signing.RSA;
 
 interface
 

--- a/Source/JOSE/JOSE.Core.JWA.Factory.pas
+++ b/Source/JOSE/JOSE.Core.JWA.Factory.pas
@@ -129,6 +129,9 @@ begin
     .RegisterAlgorithm(THmacUsingShaAlgorithm.HmacSha256)
     .RegisterAlgorithm(THmacUsingShaAlgorithm.HmacSha384)
     .RegisterAlgorithm(THmacUsingShaAlgorithm.HmacSha512)
+    .RegisterAlgorithm(TRSAUsingShaAlgorithm.RSA256)
+    .RegisterAlgorithm(TRSAUsingShaAlgorithm.RSA384)
+    .RegisterAlgorithm(TRSAUsingShaAlgorithm.RSA512)
   ;
 
   FEncryptionAlgorithmRegistry := TJOSEAlgorithmRegistry<IJOSEEncryptionAlgorithm>.Create('alg');

--- a/Source/JOSE/JOSE.Core.JWA.Signing.pas
+++ b/Source/JOSE/JOSE.Core.JWA.Signing.pas
@@ -34,7 +34,7 @@ uses
   System.SysUtils,
   JOSE.Types.Bytes,
   JOSE.Hashing.HMAC,
-  JOSE.Cryptography.RSA,
+  JOSE.Signing.RSA,
   JOSE.Core.Base,
   JOSE.Core.Parts,
   JOSE.Core.JWA,

--- a/Source/JOSE/JOSE.Core.JWS.pas
+++ b/Source/JOSE/JOSE.Core.JWS.pas
@@ -109,6 +109,9 @@ begin
 
   Result := TJOSEAlgorithmRegistryFactory.Instance
     .SigningAlgorithmRegistry.GetAlgorithm(LAlgId);
+  if Result = nil then
+    raise EJOSEException.CreateFmt('Signing algorithm (%s) is not supported.',
+      [LAlgId]);
 end;
 
 function TJWS.GetCompactToken: TJOSEBytes;


### PR DESCRIPTION
Added support for RSA signing and verifying tokens. Supported RSA-SHA256, SHA384 and SHA512 algorithms.
Public and private keys must be in PEM format. Public key can start with "-----BEGIN PUBLIC KEY-----" and "-----BEGIN RSA PUBLIC KEY-----", both in PEM format, but have different internal format.