### PR TITLE
A small correction for Delphi for Android in the method TRSA.VerifyWithCertificate

### DIFF
--- a/Source/Common/JOSE.Encoding.Base64.pas
+++ b/Source/Common/JOSE.Encoding.Base64.pas
@@ -27,6 +27,8 @@ unit JOSE.Encoding.Base64;
 
 interface
 
+{$LEGACYIFEND ON}
+
 uses
   System.SysUtils,
   {$IF CompilerVersion >= 28}

--- a/Source/Common/JOSE.Signing.RSA.pas
+++ b/Source/Common/JOSE.Signing.RSA.pas
@@ -335,7 +335,7 @@ begin
       if EVP_DigestVerifyUpdate(LCtx, @AInput[0], Length(AInput)) <> 1 then
         raise Exception.Create('[RSA] Unable to update context with payload: ' + ERR_GetErrorMessage_OpenSSL);
 
-      Result := EVP_DigestVerifyFinal(LCtx, PAnsiChar(@ASignature[0]), length(ASignature)) = 1;
+      Result := EVP_DigestVerifyFinal(LCtx, PIdAnsiChar(@ASignature[0]), length(ASignature)) = 1;
     finally
       _EVP_MD_CTX_destroy(LCtx);
     end;


### PR DESCRIPTION
In order to compile the library also for Android this small change is nessesary. Unfortunately, I was not able to add the open ssl library properly into my samples project "CloudClipboard" in order to check the token verification on Android by using the open ssl library. 