### PR TITLE
Linux x64 compatibility

### DIFF
--- a/Source/Common/JOSE.OpenSSL.Headers.pas
+++ b/Source/Common/JOSE.OpenSSL.Headers.pas
@@ -40,6 +40,11 @@ type
   PBytes = ^TBytes;
   PPBIGNUM = ^PBIGNUM;
 
+  {$IFDEF NEXTGEN}
+    AnsiChar = WideChar;
+    PAnsiChar = PWideChar;
+  {$ENDIF NEXTGEN}
+
   JoseSSL = class
   public
     //ECDASA Keys

--- a/Source/Common/JOSE.Types.Utils.pas
+++ b/Source/Common/JOSE.Types.Utils.pas
@@ -28,6 +28,11 @@ uses
   System.SysUtils;
 
 type
+  {$IFDEF NEXTGEN}
+    AnsiChar = WideChar;
+    PAnsiChar = PWideChar;
+  {$ENDIF NEXTGEN}
+
   TJOSEUtils = class
     class procedure ArrayPush(const ASource: TBytes; var ADest: TBytes; ACount: Integer);
     class function DirectoryUp(const ADirectory: string; ALevel: Integer = 1): string;


### PR DESCRIPTION
AnsiChar and PAnsiChar are not defined for Linux compilation on Delphi 10.2 or higher.