### PR TITLE
Fix Compiler Warning in Berlin 10.1

### DIFF
--- a/Source/Common/JOSE.Signing.Base.pas
+++ b/Source/Common/JOSE.Signing.Base.pas
@@ -96,6 +96,7 @@ var
   LCer: PX509;
   LAlg: Integer;
 begin
+  Result := nil;  //prevent compiler warning
   LoadOpenSSL;
 
   LCer := LoadCertificate(ACertificate);


### PR DESCRIPTION
Since some CI policies require 0 warnings and 0 errors I have "fixed" the warning Berlin 10.1 reports.