### PR TITLE
Fixed AV when calling DeserializeOnly without passing TJWTClaimsClass

### DIFF
--- a/Source/JOSE/JOSE.Core.JWT.pas
+++ b/Source/JOSE/JOSE.Core.JWT.pas
@@ -204,7 +204,10 @@ end;
 constructor TJWT.Create(AHeaderClass: TJWTHeaderClass; AClaimsClass: TJWTClaimsClass);
 begin
   FHeader := AHeaderClass.Create;
-  FClaims := AClaimsClass.Create;
+  if AClaimsClass = nil then
+    FClaims := TJWTClaims.Create
+  else
+    FClaims := AClaimsClass.Create;
 end;
 
 destructor TJWT.Destroy;


### PR DESCRIPTION
Parts of the code allows passing nil as TJWTClaimsClass, but that ends up in the TJWT.Create overload that tries to instantiate the claims directly without testing for nil. This fixes the issue.