### PR TITLE
Provider abstraction for crypto and encoding (resolves #94)

### DIFF
--- a/Packages/10.1Berlin/JOSE.dpk
+++ b/Packages/10.1Berlin/JOSE.dpk
@@ -59,6 +59,10 @@ requires
 
 contains
   JOSE.OpenSSL.Headers in '..\..\Source\Common\JOSE.OpenSSL.Headers.pas',
+  JOSE.Crypto.Algorithms in '..\..\Source\Common\JOSE.Crypto.Algorithms.pas',
+  JOSE.Providers.Interfaces in '..\..\Source\Common\JOSE.Providers.Interfaces.pas',
+  JOSE.Providers.Default in '..\..\Source\Common\JOSE.Providers.Default.pas',
+  JOSE.Providers in '..\..\Source\Common\JOSE.Providers.pas',
   JOSE.Encoding.Base64 in '..\..\Source\Common\JOSE.Encoding.Base64.pas',
   JOSE.Hashing.HMAC in '..\..\Source\Common\JOSE.Hashing.HMAC.pas',
   JOSE.Signing.Base in '..\..\Source\Common\JOSE.Signing.Base.pas',

--- a/Packages/10.2Tokyo/JOSE.dpk
+++ b/Packages/10.2Tokyo/JOSE.dpk
@@ -59,6 +59,10 @@ requires
 
 contains
   JOSE.OpenSSL.Headers in '..\..\Source\Common\JOSE.OpenSSL.Headers.pas',
+  JOSE.Crypto.Algorithms in '..\..\Source\Common\JOSE.Crypto.Algorithms.pas',
+  JOSE.Providers.Interfaces in '..\..\Source\Common\JOSE.Providers.Interfaces.pas',
+  JOSE.Providers.Default in '..\..\Source\Common\JOSE.Providers.Default.pas',
+  JOSE.Providers in '..\..\Source\Common\JOSE.Providers.pas',
   JOSE.Encoding.Base64 in '..\..\Source\Common\JOSE.Encoding.Base64.pas',
   JOSE.Hashing.HMAC in '..\..\Source\Common\JOSE.Hashing.HMAC.pas',
   JOSE.Signing.Base in '..\..\Source\Common\JOSE.Signing.Base.pas',

--- a/Packages/10.3Rio/JOSE.dpk
+++ b/Packages/10.3Rio/JOSE.dpk
@@ -60,6 +60,10 @@ requires
 
 contains
   JOSE.OpenSSL.Headers in '..\..\Source\Common\JOSE.OpenSSL.Headers.pas',
+  JOSE.Crypto.Algorithms in '..\..\Source\Common\JOSE.Crypto.Algorithms.pas',
+  JOSE.Providers.Interfaces in '..\..\Source\Common\JOSE.Providers.Interfaces.pas',
+  JOSE.Providers.Default in '..\..\Source\Common\JOSE.Providers.Default.pas',
+  JOSE.Providers in '..\..\Source\Common\JOSE.Providers.pas',
   JOSE.Encoding.Base64 in '..\..\Source\Common\JOSE.Encoding.Base64.pas',
   JOSE.Hashing.HMAC in '..\..\Source\Common\JOSE.Hashing.HMAC.pas',
   JOSE.Signing.Base in '..\..\Source\Common\JOSE.Signing.Base.pas',

--- a/Packages/10.4Sydney/JOSE.dpk
+++ b/Packages/10.4Sydney/JOSE.dpk
@@ -60,6 +60,10 @@ requires
 
 contains
   JOSE.OpenSSL.Headers in '..\..\Source\Common\JOSE.OpenSSL.Headers.pas',
+  JOSE.Crypto.Algorithms in '..\..\Source\Common\JOSE.Crypto.Algorithms.pas',
+  JOSE.Providers.Interfaces in '..\..\Source\Common\JOSE.Providers.Interfaces.pas',
+  JOSE.Providers.Default in '..\..\Source\Common\JOSE.Providers.Default.pas',
+  JOSE.Providers in '..\..\Source\Common\JOSE.Providers.pas',
   JOSE.Encoding.Base64 in '..\..\Source\Common\JOSE.Encoding.Base64.pas',
   JOSE.Hashing.HMAC in '..\..\Source\Common\JOSE.Hashing.HMAC.pas',
   JOSE.Signing.Base in '..\..\Source\Common\JOSE.Signing.Base.pas',

--- a/Packages/11AndLater/JOSE.dpk
+++ b/Packages/11AndLater/JOSE.dpk
@@ -60,6 +60,10 @@ requires
 
 contains
   JOSE.OpenSSL.Headers in '..\..\Source\Common\JOSE.OpenSSL.Headers.pas',
+  JOSE.Crypto.Algorithms in '..\..\Source\Common\JOSE.Crypto.Algorithms.pas',
+  JOSE.Providers.Interfaces in '..\..\Source\Common\JOSE.Providers.Interfaces.pas',
+  JOSE.Providers.Default in '..\..\Source\Common\JOSE.Providers.Default.pas',
+  JOSE.Providers in '..\..\Source\Common\JOSE.Providers.pas',
   JOSE.Encoding.Base64 in '..\..\Source\Common\JOSE.Encoding.Base64.pas',
   JOSE.Hashing.HMAC in '..\..\Source\Common\JOSE.Hashing.HMAC.pas',
   JOSE.Signing.Base in '..\..\Source\Common\JOSE.Signing.Base.pas',

--- a/Samples/CryptoTest/Crypto.Form.ECDSA.pas
+++ b/Samples/CryptoTest/Crypto.Form.ECDSA.pas
@@ -28,6 +28,7 @@ uses
   Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
   Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls, Crypto.Utils,
 
+  JOSE.Crypto.Algorithms,
   JOSE.Encoding.Base64,
   JOSE.Signing.ECDSA,
   JOSE.Types.Bytes,
@@ -86,7 +87,7 @@ var
   LCert: TJOSEBytes;
 begin
   LCert := Sanitize(memoCertificate.Lines.Text);
-  if TECDSA.VerifyCertificate(LCert.AsBytes, JoseSSL.NID_X9_62_id_ecPublicKey) then
+  if TECDSA.VerifyCertificate(LCert.AsBytes, TJOSECertificatePublicKey.EC) then
     ShowMessage('certificate verified. EC Key detected')
   else
     ShowMessage('certificate not verified')
@@ -225,8 +226,6 @@ var
 
   LHash: TBytes;
 begin
-  TECDSA.LoadOpenSSL;
-
   LHash := HashFromSignature(AInput);
 
   // Load Private Key into ECDSA object
@@ -306,7 +305,6 @@ var
   sig: PECDSA_SIG;
   psig: Pointer;
 begin
-  TECDSA.LoadOpenSSL;
   sig := nil;
 
   // Load Public RSA Key into RSA object

--- a/Samples/CryptoTest/Crypto.Form.RSA.pas
+++ b/Samples/CryptoTest/Crypto.Form.RSA.pas
@@ -28,11 +28,10 @@ uses
   Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
   Vcl.Controls, Vcl.Forms, Vcl.Dialogs, Vcl.StdCtrls,
 
+  JOSE.Crypto.Algorithms,
   JOSE.Encoding.Base64,
   JOSE.Signing.RSA,
-  JOSE.Types.Bytes,
-  IdSSLOpenSSLHeaders,
-  JOSE.OpenSSL.Headers;
+  JOSE.Types.Bytes;
 
 type
   TfrmCryptoRSA = class(TForm)
@@ -61,7 +60,7 @@ var
   LCert: TJOSEBytes;
 begin
   LCert := Sanitize(memoCertificate.Lines.Text);
-  if TRSA.VerifyCertificate(LCert.AsBytes, NID_rsaEncryption) then
+  if TRSA.VerifyCertificate(LCert.AsBytes, TJOSECertificatePublicKey.RSA) then
     ShowMessage('certificate verified. RSA Key detected')
   else
     ShowMessage('certificate not verified')

--- a/Samples/CryptoTest/Crypto.Form.SSL.pas
+++ b/Samples/CryptoTest/Crypto.Form.SSL.pas
@@ -262,7 +262,6 @@ var
   //LKey: PEVP_PKEY;
   LAlg: Integer;
 begin
-  TECDSA.LoadOpenSSL;
   LBio := BIO_new(BIO_s_mem);
   try
     BIO_write(LBio, @ACertificate[0], Length(ACertificate));

--- a/Samples/CryptoTest/Crypto.Form.SSL.pas
+++ b/Samples/CryptoTest/Crypto.Form.SSL.pas
@@ -121,8 +121,8 @@ begin
     '54h4FRWyuXpoQ';
   e64 := 'AQAB';
 
-  nJOSE := TBase64.Decode(n64);
-  eJOSE := TBase64.Decode(e64);
+  nJOSE := TBase64.URLDecode(n64);
+  eJOSE := TBase64.URLDecode(e64);
 
   nArr := nJOSE;
   eArr := eJOSE;

--- a/Source/Common/JOSE.Crypto.Algorithms.pas
+++ b/Source/Common/JOSE.Crypto.Algorithms.pas
@@ -1,0 +1,142 @@
+{******************************************************************************}
+{                                                                              }
+{  Delphi JOSE Library                                                         }
+{  Copyright (c) 2015 Paolo Rossi                                              }
+{  https://github.com/paolo-rossi/delphi-jose-jwt                              }
+{                                                                              }
+{******************************************************************************}
+{                                                                              }
+{  Licensed under the Apache License, Version 2.0 (the "License");             }
+{  you may not use this file except in compliance with the License.            }
+{  You may obtain a copy of the License at                                     }
+{                                                                              }
+{      http://www.apache.org/licenses/LICENSE-2.0                              }
+{                                                                              }
+{  Unless required by applicable law or agreed to in writing, software         }
+{  distributed under the License is distributed on an "AS IS" BASIS,           }
+{  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    }
+{  See the License for the specific language governing permissions and         }
+{  limitations under the License.                                              }
+{                                                                              }
+{******************************************************************************}
+
+unit JOSE.Crypto.Algorithms;
+
+{$I ..\JOSE.inc}
+
+interface
+
+uses
+  System.SysUtils;
+
+type
+  THMACAlgorithm = (SHA256, SHA384, SHA512);
+  THMACAlgorithmHelper = record helper for THMACAlgorithm
+    procedure FromString(const AValue: string);
+    function ToString: string;
+  end;
+
+{$IFDEF RSA_SIGNING}
+
+  /// <summary>Declared algorithm in an X.509 SubjectPublicKeyInfo (PEM certificate).</summary>
+  TJOSECertificatePublicKey = (RSA, EC);
+
+  TRSAAlgorithm = (RS256, RS384, RS512);
+  TRSAAlgorithmHelper = record helper for TRSAAlgorithm
+    procedure FromString(const AValue: string);
+    function ToString: string;
+  end;
+
+  TECDSAAlgorithm = (ES256, ES256K, ES384, ES512);
+  TECDSAAlgorithmHelper = record helper for TECDSAAlgorithm
+    procedure FromString(const AValue: string);
+    function ToString: string;
+  end;
+
+{$ENDIF}
+
+implementation
+
+{$IFDEF RSA_SIGNING}
+uses
+  JOSE.Signing.Base;
+{$ENDIF}
+
+{ THMACAlgorithmHelper }
+
+procedure THMACAlgorithmHelper.FromString(const AValue: string);
+begin
+  if AValue = 'SHA256' then
+    Self := SHA256
+  else if AValue = 'SHA384' then
+    Self := SHA384
+  else if AValue = 'SHA512' then
+    Self := SHA512
+  else
+    raise Exception.Create('Invalid HMAC algorithm type');
+end;
+
+function THMACAlgorithmHelper.ToString: string;
+begin
+  case Self of
+    SHA256: Result := 'SHA256';
+    SHA384: Result := 'SHA384';
+    SHA512: Result := 'SHA512';
+  end;
+end;
+
+{$IFDEF RSA_SIGNING}
+
+{ TRSAAlgorithmHelper }
+
+procedure TRSAAlgorithmHelper.FromString(const AValue: string);
+begin
+  if AValue = 'RS256' then
+    Self := RS256
+  else if AValue = 'RS384' then
+    Self := RS384
+  else if AValue = 'RS512' then
+    Self := RS512
+  else
+    raise Exception.Create('Invalid RSA algorithm type');
+end;
+
+function TRSAAlgorithmHelper.ToString: string;
+begin
+  Result := '';
+  case Self of
+    RS256: Result := 'RS256';
+    RS384: Result := 'RS384';
+    RS512: Result := 'RS512';
+  end;
+end;
+
+{ TECDSAAlgorithmHelper }
+
+procedure TECDSAAlgorithmHelper.FromString(const AValue: string);
+begin
+  if AValue = 'ES256' then
+    Self := ES256
+  else if AValue = 'ES256K' then
+    Self := ES256K
+  else if AValue = 'ES384' then
+    Self := ES384
+  else if AValue = 'ES512' then
+    Self := ES512
+  else
+    raise ESignException.Create('Invalid ECDSA algorithm type');
+end;
+
+function TECDSAAlgorithmHelper.ToString: string;
+begin
+  case Self of
+    ES256: Result := 'ES256';
+    ES256K: Result := 'ES256K';
+    ES384: Result := 'ES384';
+    ES512: Result := 'ES512';
+  end;
+end;
+
+{$ENDIF}
+
+end.

--- a/Source/Common/JOSE.Encoding.Base64.pas
+++ b/Source/Common/JOSE.Encoding.Base64.pas
@@ -31,9 +31,6 @@ interface
 
 uses
   System.SysUtils,
-  {$IF CompilerVersion >= 28}
-  System.NetEncoding,
-  {$IFEND}
   JOSE.Types.Bytes;
 
 type
@@ -49,187 +46,39 @@ type
 
 implementation
 
-{$IF CompilerVersion <= 27}
-type
-  TPacket = packed record
-    case Integer of
-      0: (b0, b1, b2, b3: Byte);
-      1: (i: Integer);
-      2: (a: array[0..3] of Byte);
-  end;
-
-function DecodeBase64(const AInput: string): TBytes;
-const
-  DECODE_TABLE: array[#0..#127] of Integer = (
-    Byte('='), 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
-    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64,
-    64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
-    64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64
-  );
-
-  function DecodePacket(AInputBuffer: PChar; var ANumChars: Integer): TPacket;
-  begin
-    Result.a[0] :=
-      (DECODE_TABLE[AInputBuffer[0]] shl 2) or (DECODE_TABLE[AInputBuffer[1]] shr 4);
-    ANumChars := 1;
-    if AInputBuffer[2] <> '=' then
-    begin
-      Inc(ANumChars);
-      Result.a[1] := (DECODE_TABLE[AInputBuffer[1]] shl 4) or (DECODE_TABLE[AInputBuffer[2]] shr 2);
-    end;
-    if AInputBuffer[3] <> '=' then
-    begin
-      Inc(ANumChars);
-      Result.a[2] := (DECODE_TABLE[AInputBuffer[2]] shl 6) or DECODE_TABLE[AInputBuffer[3]];
-    end;
-  end;
-
-var
-  I, J, K: Integer;
-  LPacket: TPacket;
-  LLen: Integer;
-begin
-  SetLength(Result, Length(AInput) div 4 * 3);
-  LLen := 0;
-  for I := 1 to Length(AInput) div 4 do
-  begin
-    LPacket := DecodePacket(PChar(@AInput[(I - 1) * 4 + 1]), J);
-    K := 0;
-    while J > 0 do
-    begin
-      Result[LLen] := LPacket.a[K];
-      Inc(LLen);
-      Inc(K);
-      Dec(J);
-    end;
-  end;
-  SetLength(Result, LLen);
-end;
-
-function EncodeBase64(const AInput: TBytes): string;
-const
-  ENCODE_TABLE: array[0..63] of Char =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZ' +
-    'abcdefghijklmnopqrstuvwxyz' +
-    '0123456789+/';
-
-  procedure EncodePacket(const APacket: TPacket; ANumChars: Integer; AOutBuffer: PChar);
-  begin
-    AOutBuffer[0] := ENCODE_TABLE[APacket.a[0] shr 2];
-    AOutBuffer[1] := ENCODE_TABLE[((APacket.a[0] shl 4) or (APacket.a[1] shr 4)) and $0000003f];
-
-    if ANumChars < 2 then
-      AOutBuffer[2] := '='
-    else
-      AOutBuffer[2] := ENCODE_TABLE[((APacket.a[1] shl 2) or (APacket.a[2] shr 6)) and $0000003f];
-
-    if ANumChars < 3 then
-      AOutBuffer[3] := '='
-    else
-      AOutBuffer[3] := ENCODE_TABLE[APacket.a[2] and $0000003f];
-  end;
-
-var
-  I, K, J: Integer;
-  LPacket: TPacket;
-begin
-  Result := '';
-  I := (Length(AInput) div 3) * 4;
-  if Length(AInput) mod 3 > 0 then
-    Inc(I, 4);
-  SetLength(Result, I);
-  J := 1;
-  for I := 1 to Length(AInput) div 3 do
-  begin
-    LPacket.i := 0;
-    LPacket.a[0] := AInput[(I - 1) * 3];
-    LPacket.a[1] := AInput[(I - 1) * 3 + 1];
-    LPacket.a[2] := AInput[(I - 1) * 3 + 2];
-    EncodePacket(LPacket, 3, PChar(@Result[J]));
-    Inc(J, 4);
-  end;
-  K := 0;
-  LPacket.i := 0;
-  for I := Length(AInput) - (Length(AInput) mod 3) + 1 to Length(AInput) do
-  begin
-    LPacket.a[K] := Byte(AInput[I - 1]);
-    Inc(K);
-    if I = Length(AInput) then
-      EncodePacket(LPacket, Length(AInput) mod 3, PChar(@Result[J]));
-  end;
-end;
-{$IFEND}
+uses
+  JOSE.Providers;
 
 { TBase64 }
 
 class function TBase64.Decode(const ASource: TJOSEBytes): TJOSEBytes;
 begin
-  {$IF CompilerVersion >= 28}
-  Result := TNetEncoding.Base64.Decode(ASource.AsBytes);
-  {$ELSE}
-  Result := DecodeBase64(ASource.AsString);
-  {$IFEND}
+  Result := TJOSEProviders.Base64.Decode(ASource);
 end;
 
 class function TBase64.Encode(const ASource: TJOSEBytes): TJOSEBytes;
 begin
-  {$IF CompilerVersion >= 28}
-  Result := TNetEncoding.Base64.Encode(ASource.AsBytes);
-  {$ELSE}
-  Result := EncodeBase64(ASource.AsBytes);
-  {$IFEND}
+  Result := TJOSEProviders.Base64.Encode(ASource);
 end;
 
 class function TBase64.TryDecode(const ASource: TJOSEBytes): TJOSEBytes;
 begin
-  try
-    Result := Decode(ASource);
-  except
-    Result.Clear;
-  end;
+  Result := TJOSEProviders.Base64.TryDecode(ASource);
 end;
 
 class function TBase64.TryURLDecode(const ASource: TJOSEBytes): TJOSEBytes;
 begin
-  try
-    Result := URLDecode(ASource);
-  except
-    Result.Clear;
-  end;
+  Result := TJOSEProviders.Base64.TryURLDecode(ASource);
 end;
 
 class function TBase64.URLDecode(const ASource: TJOSEBytes): TJOSEBytes;
-var
-  LBase64Str: string;
 begin
-  LBase64Str := ASource;
-
-  LBase64Str := LBase64Str + StringOfChar('=', (4 - ASource.Size mod 4) mod 4);
-  LBase64Str := StringReplace(LBase64Str, '-', '+', [rfReplaceAll]);
-  LBase64Str := StringReplace(LBase64Str, '_', '/', [rfReplaceAll]);
-  Result := TBase64.Decode(LBase64Str);
+  Result := TJOSEProviders.Base64.URLDecode(ASource);
 end;
 
 class function TBase64.URLEncode(const ASource: TJOSEBytes): TJOSEBytes;
-var
-  LBase64Str: string;
 begin
-  LBase64Str := TBase64.Encode(ASource);
-
-  LBase64Str := StringReplace(LBase64Str, #13#10, '', [rfReplaceAll]);
-  LBase64Str := StringReplace(LBase64Str, #13, '', [rfReplaceAll]);
-  LBase64Str := StringReplace(LBase64Str, #10, '', [rfReplaceAll]);
-  LBase64Str := LBase64Str.TrimRight(['=']);
-
-  LBase64Str := StringReplace(LBase64Str, '+', '-', [rfReplaceAll]);
-  LBase64Str := StringReplace(LBase64Str, '/', '_', [rfReplaceAll]);
-
-  Result := LBase64Str;
+  Result := TJOSEProviders.Base64.URLEncode(ASource);
 end;
 
 end.
-

--- a/Source/Common/JOSE.Hashing.HMAC.pas
+++ b/Source/Common/JOSE.Hashing.HMAC.pas
@@ -31,23 +31,11 @@ interface
 
 uses
   System.SysUtils,
-  {$IF CompilerVersion >= 30 }  // Delphi 10 Seattle or greater
-  System.Hash,
-  {$ELSE}
-  IdGlobal,
-  IdHMAC,
-  IdHMACSHA1,
-  IdSSLOpenSSL,
-  IdHash,
-  {$IFEND}
-  JOSE.Encoding.Base64;
+  JOSE.Crypto.Algorithms;
 
 type
-  THMACAlgorithm = (SHA256, SHA384, SHA512);
-  THMACAlgorithmHelper = record helper for THMACAlgorithm
-    procedure FromString(const AValue: string);
-    function ToString: string;
-  end;
+  THMACAlgorithm = JOSE.Crypto.Algorithms.THMACAlgorithm;
+  THMACAlgorithmHelper = JOSE.Crypto.Algorithms.THMACAlgorithmHelper;
 
   THMAC = class
   public
@@ -56,67 +44,14 @@ type
 
 implementation
 
-{$IF CompilerVersion >= 30 }  // Delphi 10 Seattle or greater
+uses
+  JOSE.Providers;
+
+{ THMAC }
+
 class function THMAC.Sign(const AInput, AKey: TBytes; AAlg: THMACAlgorithm): TBytes;
-var
-  LHashAlg: THashSHA2.TSHA2Version;
 begin
-  LHashAlg := THashSHA2.TSHA2Version.SHA256;
-  case AAlg of
-    SHA256: LHashAlg := THashSHA2.TSHA2Version.SHA256;
-    SHA384: LHashAlg := THashSHA2.TSHA2Version.SHA384;
-    SHA512: LHashAlg := THashSHA2.TSHA2Version.SHA512;
-  end;
-  Result := THashSHA2.GetHMACAsBytes(AInput, AKey, LHashAlg);
-end;
-
-{$ELSE}
-class function THMAC.Sign(const AInput, AKey: TBytes; AAlg: THMACAlgorithm): TBytes;
-var
-  LSigner: TIdHMAC;
-begin
-  LSigner := nil;
-
-  if not IdSSLOpenSSL.LoadOpenSSLLibrary then
-    raise Exception.Create('Error Loading OpenSSL libraries');
-
-  case AAlg of
-    SHA256: LSigner := TIdHMACSHA256.Create;
-    SHA384: LSigner := TIdHMACSHA384.Create;
-    SHA512: LSigner := TIdHMACSHA512.Create;
-  end;
-
-  try
-    LSigner.Key := TIdBytes(AKey);
-    Result:= TBytes(LSigner.HashValue(TIdBytes(AInput)));
-  finally
-    LSigner.Free;
-  end;
-end;
-{$IFEND}
-
-
-{ THMACAlgorithmHelper }
-
-procedure THMACAlgorithmHelper.FromString(const AValue: string);
-begin
-  if AValue = 'SHA256' then
-    Self := SHA256
-  else if AValue = 'SHA384' then
-    Self := SHA384
-  else if AValue = 'SHA512' then
-    Self := SHA512
-  else
-    raise Exception.Create('Invalid HMAC algorithm type');
-end;
-
-function THMACAlgorithmHelper.ToString: string;
-begin
-  case Self of
-    SHA256: Result := 'SHA256';
-    SHA384: Result := 'SHA384';
-    SHA512: Result := 'SHA512';
-  end;
+  Result := TJOSEProviders.HMAC.Sign(AInput, AKey, AAlg);
 end;
 
 end.

--- a/Source/Common/JOSE.Providers.CryptoLib.pas
+++ b/Source/Common/JOSE.Providers.CryptoLib.pas
@@ -405,7 +405,6 @@ var
   LCert: IX509Certificate;
   LAlg, LExp: IDerObjectIdentifier;
 begin
-  Result := False;
   try
     LParser := TX509CertificateParser.Create;
     LCert := LParser.ReadCertificate(ACertificate);
@@ -477,7 +476,6 @@ function TCryptoLibRSAProvider.VerifyWithRsa(const AInput, ASignature: TBytes; c
 var
   LSigner: ISigner;
 begin
-  Result := False;
   try
     LSigner := TSignerUtilities.InitSigner(RsaMechanism(AAlg), False, AKey, nil);
     LSigner.BlockUpdate(AInput, 0, Length(AInput));
@@ -499,7 +497,6 @@ function TCryptoLibRSAProvider.Verify(const AInput, ASignature, AKey: TBytes; AA
 var
   LPub: IAsymmetricKeyParameter;
 begin
-  Result := False;
   try
     LPub := PemToPublicKey(AKey);
     Result := VerifyWithRsa(AInput, ASignature, LPub, AAlg);
@@ -512,7 +509,6 @@ function TCryptoLibRSAProvider.VerifyWithCertificate(const AInput, ASignature, A
 var
   LPub: IAsymmetricKeyParameter;
 begin
-  Result := False;
   try
     LPub := PemToPublicKey(ACertificate);
     Result := VerifyWithRsa(AInput, ASignature, LPub, AAlg);
@@ -629,7 +625,6 @@ function TCryptoLibECDSAProvider.VerifyWithEc(const AInput, ASignature: TBytes; 
 var
   LSigner: ISigner;
 begin
-  Result := False;
   try
     EnsureNamedCurve(AKey, AAlg);
     LSigner := TSignerUtilities.InitSigner(EcdsaMechanism(AAlg), False, AKey, nil);
@@ -652,7 +647,6 @@ function TCryptoLibECDSAProvider.Verify(const AInput, ASignature, APublicKey: TB
 var
   LPub: IAsymmetricKeyParameter;
 begin
-  Result := False;
   try
     LPub := PemToPublicKey(APublicKey);
     Result := VerifyWithEc(AInput, ASignature, LPub, AAlg);
@@ -665,7 +659,6 @@ function TCryptoLibECDSAProvider.VerifyWithCertificate(const AInput, ASignature,
 var
   LPub: IAsymmetricKeyParameter;
 begin
-  Result := False;
   try
     LPub := PemToPublicKey(ACertificate);
     Result := VerifyWithEc(AInput, ASignature, LPub, AAlg);

--- a/Source/Common/JOSE.Providers.CryptoLib.pas
+++ b/Source/Common/JOSE.Providers.CryptoLib.pas
@@ -155,7 +155,7 @@ end;
 
 function TCryptoLibBase64Provider.Decode(const ASource: TJOSEBytes): TJOSEBytes;
 begin
-  Result := SbpBase64.TBase64.Default.Decode(ASource.AsString);
+  Result := SbpBase64.TBase64.Default.Decode(Trim(ASource.AsString));
 end;
 
 function TCryptoLibBase64Provider.TryDecode(const ASource: TJOSEBytes): TJOSEBytes;
@@ -165,7 +165,7 @@ var
   LText: string;
 begin
   Result.Clear;
-  LText := ASource.AsString;
+  LText := Trim(ASource.AsString);
   if LText = '' then
     Exit;
   SetLength(LBuf, SbpBase64.TBase64.Default.GetSafeByteCountForDecoding(LText));
@@ -175,7 +175,7 @@ end;
 
 function TCryptoLibBase64Provider.URLDecode(const ASource: TJOSEBytes): TJOSEBytes;
 begin
-  Result := SbpBase64.TBase64.Url.Decode(ASource.AsString);
+  Result := SbpBase64.TBase64.Url.Decode(Trim(ASource.AsString));
 end;
 
 function TCryptoLibBase64Provider.URLEncode(const ASource: TJOSEBytes): TJOSEBytes;
@@ -191,7 +191,7 @@ var
   LBufChars: Integer;
 begin
   Result.Clear;
-  LText := ASource.AsString;
+  LText := Trim(ASource.AsString);
   if LText = '' then
     Exit;
   LBufChars := Length(LText);

--- a/Source/Common/JOSE.Providers.CryptoLib.pas
+++ b/Source/Common/JOSE.Providers.CryptoLib.pas
@@ -64,7 +64,7 @@ type
     function SignWithRsa(const AInput: TBytes; const AKey: IAsymmetricKeyParameter; AAlg: TRSAAlgorithm): TBytes;
     function VerifyWithRsa(const AInput, ASignature: TBytes; const AKey: IAsymmetricKeyParameter; AAlg: TRSAAlgorithm): Boolean;
   public
-    constructor Create(ACertificate: IJOSECertificateProvider);
+    constructor Create(const ACertificate: IJOSECertificateProvider);
     function Sign(const AInput, AKey: TBytes; AAlg: TRSAAlgorithm): TBytes;
     function Verify(const AInput, ASignature, AKey: TBytes; AAlg: TRSAAlgorithm): Boolean;
     function VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TRSAAlgorithm): Boolean;
@@ -82,7 +82,7 @@ type
     function SignWithEc(const AInput: TBytes; const AKey: IAsymmetricKeyParameter; AAlg: TECDSAAlgorithm): TBytes;
     function VerifyWithEc(const AInput, ASignature: TBytes; const AKey: IAsymmetricKeyParameter; AAlg: TECDSAAlgorithm): Boolean;
   public
-    constructor Create(ACertificate: IJOSECertificateProvider);
+    constructor Create(const ACertificate: IJOSECertificateProvider);
     function Sign(const AInput, APrivateKey: TBytes; AAlg: TECDSAAlgorithm): TBytes;
     function Verify(const AInput, ASignature, APublicKey: TBytes; AAlg: TECDSAAlgorithm): Boolean;
     function VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TECDSAAlgorithm): Boolean;
@@ -418,7 +418,7 @@ end;
 
 { TCryptoLibRSAProvider }
 
-constructor TCryptoLibRSAProvider.Create(ACertificate: IJOSECertificateProvider);
+constructor TCryptoLibRSAProvider.Create(const ACertificate: IJOSECertificateProvider);
 begin
   inherited Create;
   FCertificate := ACertificate;
@@ -539,7 +539,7 @@ end;
 
 { TCryptoLibECDSAProvider }
 
-constructor TCryptoLibECDSAProvider.Create(ACertificate: IJOSECertificateProvider);
+constructor TCryptoLibECDSAProvider.Create(const ACertificate: IJOSECertificateProvider);
 begin
   inherited Create;
   FCertificate := ACertificate;

--- a/Source/Common/JOSE.Providers.CryptoLib.pas
+++ b/Source/Common/JOSE.Providers.CryptoLib.pas
@@ -1,0 +1,720 @@
+{******************************************************************************}
+{                                                                              }
+{  Delphi JOSE Library                                                         }
+{  Copyright (c) 2015 Paolo Rossi                                              }
+{  https://github.com/paolo-rossi/delphi-jose-jwt                              }
+{                                                                              }
+{******************************************************************************}
+{                                                                              }
+{  Licensed under the Apache License, Version 2.0 (the "License");             }
+{  you may not use this file except in compliance with the License.            }
+{  You may obtain a copy of the License at                                     }
+{                                                                              }
+{      http://www.apache.org/licenses/LICENSE-2.0                              }
+{                                                                              }
+{  Unless required by applicable law or agreed to in writing, software         }
+{  distributed under the License is distributed on an "AS IS" BASIS,           }
+{  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    }
+{  See the License for the specific language governing permissions and         }
+{  limitations under the License.                                              }
+{                                                                              }
+{******************************************************************************}
+
+unit JOSE.Providers.CryptoLib;
+
+{$I ..\JOSE.inc}
+
+interface
+
+uses
+  System.SysUtils,
+  JOSE.Types.Bytes,
+  JOSE.Providers.Interfaces,
+  JOSE.Crypto.Algorithms,
+  ClpIAsymmetricKeyParameter;
+
+type
+  TCryptoLibBase64Provider = class(TInterfacedObject, IJOSEBase64Provider)
+  public
+    function Encode(const ASource: TJOSEBytes): TJOSEBytes;
+    function Decode(const ASource: TJOSEBytes): TJOSEBytes;
+    function TryDecode(const ASource: TJOSEBytes): TJOSEBytes;
+    function URLEncode(const ASource: TJOSEBytes): TJOSEBytes;
+    function URLDecode(const ASource: TJOSEBytes): TJOSEBytes;
+    function TryURLDecode(const ASource: TJOSEBytes): TJOSEBytes;
+  end;
+
+  TCryptoLibHmacProvider = class(TInterfacedObject, IJOSEHmacProvider)
+  public
+    function Sign(const AInput, AKey: TBytes; AAlg: THMACAlgorithm): TBytes;
+  end;
+
+  TCryptoLibCertificateProvider = class(TInterfacedObject, IJOSECertificateProvider)
+  public
+    function PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
+    function VerifyCertificate(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): Boolean;
+  end;
+
+  TCryptoLibRSAProvider = class(TInterfacedObject, IJOSESignerRSA)
+  private
+    FCertificate: IJOSECertificateProvider;
+    function PemToPublicKey(const APem: TBytes): IAsymmetricKeyParameter;
+    function PemToPrivateKey(const APem: TBytes): IAsymmetricKeyParameter;
+    function RsaMechanism(AAlg: TRSAAlgorithm): string;
+    function SignWithRsa(const AInput: TBytes; const AKey: IAsymmetricKeyParameter; AAlg: TRSAAlgorithm): TBytes;
+    function VerifyWithRsa(const AInput, ASignature: TBytes; const AKey: IAsymmetricKeyParameter; AAlg: TRSAAlgorithm): Boolean;
+  public
+    constructor Create(ACertificate: IJOSECertificateProvider);
+    function Sign(const AInput, AKey: TBytes; AAlg: TRSAAlgorithm): TBytes;
+    function Verify(const AInput, ASignature, AKey: TBytes; AAlg: TRSAAlgorithm): Boolean;
+    function VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TRSAAlgorithm): Boolean;
+    function VerifyPublicKey(const AKey: TBytes): Boolean;
+    function VerifyPrivateKey(const AKey: TBytes): Boolean;
+  end;
+
+  TCryptoLibECDSAProvider = class(TInterfacedObject, IJOSESignerECDSA)
+  private
+    FCertificate: IJOSECertificateProvider;
+    procedure EnsureNamedCurve(const AKey: IAsymmetricKeyParameter; AAlg: TECDSAAlgorithm);
+    function EcdsaMechanism(AAlg: TECDSAAlgorithm): string;
+    function PemToPublicKey(const APem: TBytes): IAsymmetricKeyParameter;
+    function PemToPrivateKey(const APem: TBytes): IAsymmetricKeyParameter;
+    function SignWithEc(const AInput: TBytes; const AKey: IAsymmetricKeyParameter; AAlg: TECDSAAlgorithm): TBytes;
+    function VerifyWithEc(const AInput, ASignature: TBytes; const AKey: IAsymmetricKeyParameter; AAlg: TECDSAAlgorithm): Boolean;
+  public
+    constructor Create(ACertificate: IJOSECertificateProvider);
+    function Sign(const AInput, APrivateKey: TBytes; AAlg: TECDSAAlgorithm): TBytes;
+    function Verify(const AInput, ASignature, APublicKey: TBytes; AAlg: TECDSAAlgorithm): Boolean;
+    function VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TECDSAAlgorithm): Boolean;
+    function VerifyPublicKey(const AKey: TBytes): Boolean;
+    function VerifyPrivateKey(const AKey: TBytes): Boolean;
+  end;
+
+  TJOSECryptoLibProviders = class
+  public
+    /// <summary>Wires CryptoLib implementations into <see cref="JOSE.Providers|TJOSEProviders"/> (Base64, HMAC, cert, RSA, ECDSA).</summary>
+    class procedure Register; static;
+    /// <summary>Clears <see cref="JOSE.Providers|TJOSEProviders"/> slots previously set by <see cref="Register"/>.</summary>
+    class procedure Unregister; static;
+  end;
+
+implementation
+
+uses
+  JOSE.Providers,
+  System.Classes,
+  System.Rtti,
+  ClpMacUtilities,
+  ClpKeyParameter,
+  ClpICipherParameters,
+  ClpCryptoLibTypes,
+  ClpSignerUtilities,
+  ClpISigner,
+  ClpSecureRandom,
+  ClpISecureRandom,
+  ClpOpenSslPemReader,
+  ClpOpenSslPemWriter,
+  ClpX509CertificateParser,
+  ClpIX509CertificateParser,
+  ClpIX509Certificate,
+  ClpIAsymmetricCipherKeyPair,
+  ClpIAsn1Objects,
+  ClpIX509Asn1Objects,
+  ClpPkcsObjectIdentifiers,
+  ClpX9ObjectIdentifiers,
+  ClpSecObjectIdentifiers,
+  ClpIRsaParameters,
+  ClpIECParameters,
+  SbpBase64,
+  JOSE.Signing.Base;
+
+{ TJOSECryptoLibPem }
+
+type
+  TJOSECryptoLibPem = class
+  strict private
+    /// <summary>First PEM object must be SPKI / public key (not an X.509 certificate).</summary>
+    class function ReadPublicKeyMaterial(const APem: TBytes): IAsymmetricKeyParameter; static;
+    class function ParsePublicKeyFromDecodedPem(const LVal: TValue): IAsymmetricKeyParameter; static;
+  public
+    class function ReadPrivateKey(const APem: TBytes): IAsymmetricKeyParameter; static;
+    /// <summary>
+    /// Reads a public key from PEM. Dispatches on PEM type (e.g. CERTIFICATE vs PUBLIC KEY).
+    /// For certificate PEM, <paramref name="ACertProvider"/> must decode and validate <paramref name="ACertExpected"/>.
+    /// </summary>
+    class function ReadPublicKey(const APem: TBytes; const ACertProvider: IJOSECertificateProvider;
+      ACertExpected: TJOSECertificatePublicKey): IAsymmetricKeyParameter; static;
+  end;
+
+{ TCryptoLibBase64Provider }
+
+function TCryptoLibBase64Provider.Encode(const ASource: TJOSEBytes): TJOSEBytes;
+begin
+  Result := SbpBase64.TBase64.Default.Encode(ASource.AsBytes);
+end;
+
+function TCryptoLibBase64Provider.Decode(const ASource: TJOSEBytes): TJOSEBytes;
+begin
+  Result := SbpBase64.TBase64.Default.Decode(ASource.AsString);
+end;
+
+function TCryptoLibBase64Provider.TryDecode(const ASource: TJOSEBytes): TJOSEBytes;
+var
+  LBuf: TBytes;
+  LWritten: Int32;
+  LText: string;
+begin
+  Result.Clear;
+  LText := ASource.AsString;
+  if LText = '' then
+    Exit;
+  SetLength(LBuf, SbpBase64.TBase64.Default.GetSafeByteCountForDecoding(LText));
+  if SbpBase64.TBase64.Default.TryDecode(LText, LBuf, LWritten) then
+    Result := Copy(LBuf, 0, LWritten);
+end;
+
+function TCryptoLibBase64Provider.URLDecode(const ASource: TJOSEBytes): TJOSEBytes;
+begin
+  Result := SbpBase64.TBase64.Url.Decode(ASource.AsString);
+end;
+
+function TCryptoLibBase64Provider.URLEncode(const ASource: TJOSEBytes): TJOSEBytes;
+begin
+  Result := SbpBase64.TBase64.Url.Encode(ASource.AsBytes);
+end;
+
+function TCryptoLibBase64Provider.TryURLDecode(const ASource: TJOSEBytes): TJOSEBytes;
+var
+  LBuf: TBytes;
+  LWritten: Int32;
+  LText: string;
+  LBufChars: Integer;
+begin
+  Result.Clear;
+  LText := ASource.AsString;
+  if LText = '' then
+    Exit;
+  LBufChars := Length(LText);
+  SetLength(LBuf, (LBufChars + 3) div 4 * 3);
+  if SbpBase64.TBase64.Url.TryDecode(LText, LBuf, LWritten) then
+    Result := Copy(LBuf, 0, LWritten);
+end;
+
+{ TCryptoLibHmacProvider }
+
+function HmacMechanism(AAlg: THMACAlgorithm): string;
+begin
+  case AAlg of
+    THMACAlgorithm.SHA256:
+      Result := 'HMAC-SHA256';
+    THMACAlgorithm.SHA384:
+      Result := 'HMAC-SHA384';
+    THMACAlgorithm.SHA512:
+      Result := 'HMAC-SHA512';
+  else
+    raise Exception.Create('[CryptoLib] Unsupported HMAC digest');
+  end;
+end;
+
+function TCryptoLibHmacProvider.Sign(const AInput, AKey: TBytes; AAlg: THMACAlgorithm): TBytes;
+var
+  LKeyParam: ICipherParameters;
+begin
+  try
+    LKeyParam := TKeyParameter.Create(AKey);
+    Result := TMacUtilities.CalculateMac(HmacMechanism(AAlg), LKeyParam, AInput);
+  except
+    on E: Exception do
+      raise Exception.Create('[CryptoLib] HMAC error: ' + E.Message);
+  end;
+end;
+
+class function TJOSECryptoLibPem.ReadPrivateKey(const APem: TBytes): IAsymmetricKeyParameter;
+var
+  LStream: TStringStream;
+  LReader: TOpenSslPemReader;
+  LVal: TValue;
+  LKp: IAsymmetricCipherKeyPair;
+begin
+  Result := nil;
+  LStream := TStringStream.Create(TEncoding.ASCII.GetString(APem));
+  try
+    LReader := TOpenSslPemReader.Create(LStream);
+    try
+      LVal := LReader.ReadObject();
+      if LVal.IsEmpty then
+        raise ESignException.Create('[CryptoLib] Empty PEM object');
+      if LVal.TryAsType<IAsymmetricKeyParameter>(Result) and (Result <> nil) then
+        Exit;
+      if LVal.TryAsType<IAsymmetricCipherKeyPair>(LKp) and (LKp <> nil) then
+      begin
+        Result := LKp.Private;
+        Exit;
+      end;
+      raise ESignException.Create('[CryptoLib] PEM does not contain a private key');
+    finally
+      LReader.Free;
+    end;
+  finally
+    LStream.Free;
+  end;
+end;
+
+class function TJOSECryptoLibPem.ParsePublicKeyFromDecodedPem(const LVal: TValue): IAsymmetricKeyParameter;
+var
+  LKp: IAsymmetricCipherKeyPair;
+begin
+  if LVal.TryAsType<IAsymmetricKeyParameter>(Result) and (Result <> nil) then
+    Exit;
+  if LVal.TryAsType<IAsymmetricCipherKeyPair>(LKp) and (LKp <> nil) then
+  begin
+    Result := LKp.Public;
+    Exit;
+  end;
+  raise ESignException.Create('[CryptoLib] PEM does not contain a public key');
+end;
+
+class function TJOSECryptoLibPem.ReadPublicKeyMaterial(const APem: TBytes): IAsymmetricKeyParameter;
+var
+  LStream: TStringStream;
+  LReader: TOpenSslPemReader;
+  LVal: TValue;
+  LCert: IX509Certificate;
+begin
+  LStream := TStringStream.Create(TEncoding.ASCII.GetString(APem));
+  try
+    LReader := TOpenSslPemReader.Create(LStream);
+    try
+      LVal := LReader.ReadObject();
+      if LVal.IsEmpty then
+        raise ESignException.Create('[CryptoLib] Empty PEM object');
+      if LVal.TryAsType<IX509Certificate>(LCert) and (LCert <> nil) then
+        raise ESignException.Create('[CryptoLib] Expected a public key PEM (SPKI), not an X.509 certificate PEM');
+      Result := ParsePublicKeyFromDecodedPem(LVal);
+    finally
+      LReader.Free;
+    end;
+  finally
+    LStream.Free;
+  end;
+end;
+
+class function TJOSECryptoLibPem.ReadPublicKey(const APem: TBytes; const ACertProvider: IJOSECertificateProvider;
+  ACertExpected: TJOSECertificatePublicKey): IAsymmetricKeyParameter;
+var
+  LStream: TStringStream;
+  LReader: TOpenSslPemReader;
+  LVal: TValue;
+  LCert: IX509Certificate;
+  LSpkiPem: TBytes;
+begin
+  LStream := TStringStream.Create(TEncoding.ASCII.GetString(APem));
+  try
+    LReader := TOpenSslPemReader.Create(LStream);
+    try
+      LVal := LReader.ReadObject();
+      if LVal.IsEmpty then
+        raise ESignException.Create('[CryptoLib] Empty PEM object');
+
+      if LVal.TryAsType<IX509Certificate>(LCert) and (LCert <> nil) then
+      begin
+        if ACertProvider = nil then
+          raise ESignException.Create('[CryptoLib] Certificate supplied but no IJOSECertificateProvider was configured');
+        if not ACertProvider.VerifyCertificate(APem, ACertExpected) then
+        begin
+          case ACertExpected of
+            TJOSECertificatePublicKey.RSA:
+              raise ESignException.Create('[CryptoLib] Certificate does not contain an RSA public key');
+            TJOSECertificatePublicKey.EC:
+              raise ESignException.Create('[CryptoLib] Certificate does not contain an EC public key');
+          end;
+        end;
+        LSpkiPem := ACertProvider.PublicKeyFromCertificate(APem);
+        Result := ReadPublicKeyMaterial(LSpkiPem);
+        Exit;
+      end;
+
+      Result := ParsePublicKeyFromDecodedPem(LVal);
+    finally
+      LReader.Free;
+    end;
+  finally
+    LStream.Free;
+  end;
+end;
+
+{ TCryptoLibCertificateProvider }
+
+function ExpectedCertPkAlg(AExpected: TJOSECertificatePublicKey): IDerObjectIdentifier;
+begin
+  case AExpected of
+    TJOSECertificatePublicKey.RSA:
+      Result := TPkcsObjectIdentifiers.RsaEncryption;
+    TJOSECertificatePublicKey.EC:
+      Result := TX9ObjectIdentifiers.IdECPublicKey;
+  else
+    raise EArgumentException.Create('Unhandled TJOSECertificatePublicKey value');
+  end;
+end;
+
+function WritePublicKeyPem(const APublicKey: IAsymmetricKeyParameter): TBytes;
+var
+  LStream: TMemoryStream;
+  LWriter: TOpenSslPemWriter;
+begin
+  LStream := TMemoryStream.Create;
+  try
+    LWriter := TOpenSslPemWriter.Create(LStream);
+    try
+      LWriter.WriteObject(TValue.From<IAsymmetricKeyParameter>(APublicKey));
+    finally
+      LWriter.Free;
+    end;
+    SetLength(Result, LStream.Size);
+    if LStream.Size > 0 then
+      Move(LStream.Memory^, Result[0], LStream.Size);
+  finally
+    LStream.Free;
+  end;
+end;
+
+function TCryptoLibCertificateProvider.PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
+var
+  LParser: IX509CertificateParser;
+  LCert: IX509Certificate;
+  LPub: IAsymmetricKeyParameter;
+begin
+  try
+    LParser := TX509CertificateParser.Create;
+    LCert := LParser.ReadCertificate(ACertificate);
+    LPub := LCert.GetPublicKey;
+    if LPub = nil then
+      raise ESignException.Create('[CryptoLib] Unable to read public key from certificate');
+    Result := WritePublicKeyPem(LPub);
+  except
+    on E: ESignException do
+      raise;
+    on E: Exception do
+      raise ESignException.Create('[CryptoLib] Certificate error: ' + E.Message);
+  end;
+end;
+
+function TCryptoLibCertificateProvider.VerifyCertificate(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): Boolean;
+var
+  LParser: IX509CertificateParser;
+  LCert: IX509Certificate;
+  LAlg, LExp: IDerObjectIdentifier;
+begin
+  Result := False;
+  try
+    LParser := TX509CertificateParser.Create;
+    LCert := LParser.ReadCertificate(ACertificate);
+    LAlg := LCert.SubjectPublicKeyInfo.Algorithm.Algorithm;
+    LExp := ExpectedCertPkAlg(AExpected);
+    Result := (LAlg <> nil) and (LExp <> nil) and LAlg.Equals(LExp);
+  except
+    Result := False;
+  end;
+end;
+
+{ TCryptoLibRSAProvider }
+
+constructor TCryptoLibRSAProvider.Create(ACertificate: IJOSECertificateProvider);
+begin
+  inherited Create;
+  FCertificate := ACertificate;
+end;
+
+function TCryptoLibRSAProvider.PemToPublicKey(const APem: TBytes): IAsymmetricKeyParameter;
+begin
+  Result := TJOSECryptoLibPem.ReadPublicKey(APem, FCertificate, TJOSECertificatePublicKey.RSA);
+  if not Supports(Result, IRsaKeyParameters) then
+    raise ESignException.Create('[CryptoLib] Key is not an RSA key');
+end;
+
+function TCryptoLibRSAProvider.PemToPrivateKey(const APem: TBytes): IAsymmetricKeyParameter;
+begin
+  Result := TJOSECryptoLibPem.ReadPrivateKey(APem);
+  if not Supports(Result, IRsaKeyParameters) then
+    raise ESignException.Create('[CryptoLib] Key is not an RSA private key');
+  if not Result.IsPrivate then
+    raise ESignException.Create('[CryptoLib] RSA PEM did not contain a private key');
+end;
+
+function TCryptoLibRSAProvider.RsaMechanism(AAlg: TRSAAlgorithm): string;
+begin
+  case AAlg of
+    TRSAAlgorithm.RS256:
+      Result := 'SHA-256withRSA';
+    TRSAAlgorithm.RS384:
+      Result := 'SHA-384withRSA';
+    TRSAAlgorithm.RS512:
+      Result := 'SHA-512withRSA';
+  else
+    raise ESignException.Create('[CryptoLib] Unsupported RSA JWS algorithm');
+  end;
+end;
+
+function TCryptoLibRSAProvider.SignWithRsa(const AInput: TBytes; const AKey: IAsymmetricKeyParameter; AAlg: TRSAAlgorithm): TBytes;
+var
+  LSigner: ISigner;
+  LRnd: ISecureRandom;
+begin
+  try
+    LRnd := TSecureRandom.Create();
+    LSigner := TSignerUtilities.InitSigner(RsaMechanism(AAlg), True, AKey, LRnd);
+    LSigner.BlockUpdate(AInput, 0, Length(AInput));
+    Result := LSigner.GenerateSignature();
+  except
+    on E: ESignException do
+      raise;
+    on E: Exception do
+      raise ESignException.Create('[CryptoLib] RSA sign error: ' + E.Message);
+  end;
+end;
+
+function TCryptoLibRSAProvider.VerifyWithRsa(const AInput, ASignature: TBytes; const AKey: IAsymmetricKeyParameter; AAlg: TRSAAlgorithm): Boolean;
+var
+  LSigner: ISigner;
+begin
+  Result := False;
+  try
+    LSigner := TSignerUtilities.InitSigner(RsaMechanism(AAlg), False, AKey, nil);
+    LSigner.BlockUpdate(AInput, 0, Length(AInput));
+    Result := LSigner.VerifySignature(ASignature);
+  except
+    Result := False;
+  end;
+end;
+
+function TCryptoLibRSAProvider.Sign(const AInput, AKey: TBytes; AAlg: TRSAAlgorithm): TBytes;
+var
+  LPriv: IAsymmetricKeyParameter;
+begin
+  LPriv := PemToPrivateKey(AKey);
+  Result := SignWithRsa(AInput, LPriv, AAlg);
+end;
+
+function TCryptoLibRSAProvider.Verify(const AInput, ASignature, AKey: TBytes; AAlg: TRSAAlgorithm): Boolean;
+var
+  LPub: IAsymmetricKeyParameter;
+begin
+  Result := False;
+  try
+    LPub := PemToPublicKey(AKey);
+    Result := VerifyWithRsa(AInput, ASignature, LPub, AAlg);
+  except
+    Result := False;
+  end;
+end;
+
+function TCryptoLibRSAProvider.VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TRSAAlgorithm): Boolean;
+var
+  LPub: IAsymmetricKeyParameter;
+begin
+  Result := False;
+  try
+    LPub := PemToPublicKey(ACertificate);
+    Result := VerifyWithRsa(AInput, ASignature, LPub, AAlg);
+  except
+    Result := False;
+  end;
+end;
+
+function TCryptoLibRSAProvider.VerifyPublicKey(const AKey: TBytes): Boolean;
+begin
+  try
+    PemToPublicKey(AKey);
+    Result := True;
+  except
+    Result := False;
+  end;
+end;
+
+function TCryptoLibRSAProvider.VerifyPrivateKey(const AKey: TBytes): Boolean;
+begin
+  try
+    PemToPrivateKey(AKey);
+    Result := True;
+  except
+    Result := False;
+  end;
+end;
+
+{ TCryptoLibECDSAProvider }
+
+constructor TCryptoLibECDSAProvider.Create(ACertificate: IJOSECertificateProvider);
+begin
+  inherited Create;
+  FCertificate := ACertificate;
+end;
+
+function ExpectedEcCurveOid(AAlg: TECDSAAlgorithm): IDerObjectIdentifier;
+begin
+  case AAlg of
+    TECDSAAlgorithm.ES256:
+      Result := TSecObjectIdentifiers.SecP256r1;
+    TECDSAAlgorithm.ES256K:
+      Result := TSecObjectIdentifiers.SecP256k1;
+    TECDSAAlgorithm.ES384:
+      Result := TSecObjectIdentifiers.SecP384r1;
+    TECDSAAlgorithm.ES512:
+      Result := TSecObjectIdentifiers.SecP521r1;
+  else
+    raise ESignException.Create('[CryptoLib] Unsupported ECDSA JWS algorithm');
+  end;
+end;
+
+procedure TCryptoLibECDSAProvider.EnsureNamedCurve(const AKey: IAsymmetricKeyParameter; AAlg: TECDSAAlgorithm);
+var
+  LEc: IECKeyParameters;
+  LExp, LHave: IDerObjectIdentifier;
+begin
+  if not Supports(AKey, IECKeyParameters, LEc) then
+    raise ESignException.Create('[CryptoLib] Key is not an EC key');
+  LExp := ExpectedEcCurveOid(AAlg);
+  LHave := LEc.PublicKeyParamSet;
+  if (LHave = nil) or (LExp = nil) or (LHave.ID <> LExp.ID) then
+    raise ESignException.Create('[CryptoLib] EC key curve does not match the selected JOSE algorithm');
+end;
+
+function TCryptoLibECDSAProvider.EcdsaMechanism(AAlg: TECDSAAlgorithm): string;
+begin
+  case AAlg of
+    TECDSAAlgorithm.ES256, TECDSAAlgorithm.ES256K:
+      Result := 'SHA-256withPLAIN-ECDSA';
+    TECDSAAlgorithm.ES384:
+      Result := 'SHA-384withPLAIN-ECDSA';
+    TECDSAAlgorithm.ES512:
+      Result := 'SHA-512withPLAIN-ECDSA';
+  else
+    raise ESignException.Create('[CryptoLib] Unsupported ECDSA JWS algorithm');
+  end;
+end;
+
+function TCryptoLibECDSAProvider.PemToPublicKey(const APem: TBytes): IAsymmetricKeyParameter;
+begin
+  Result := TJOSECryptoLibPem.ReadPublicKey(APem, FCertificate, TJOSECertificatePublicKey.EC);
+  if not Supports(Result, IECPublicKeyParameters) then
+    raise ESignException.Create('[CryptoLib] Key is not an EC public key');
+end;
+
+function TCryptoLibECDSAProvider.PemToPrivateKey(const APem: TBytes): IAsymmetricKeyParameter;
+begin
+  Result := TJOSECryptoLibPem.ReadPrivateKey(APem);
+  if not Supports(Result, IECPrivateKeyParameters) then
+    raise ESignException.Create('[CryptoLib] Key is not an EC private key');
+end;
+
+function TCryptoLibECDSAProvider.SignWithEc(const AInput: TBytes; const AKey: IAsymmetricKeyParameter; AAlg: TECDSAAlgorithm): TBytes;
+var
+  LSigner: ISigner;
+  LRnd: ISecureRandom;
+begin
+  EnsureNamedCurve(AKey, AAlg);
+  try
+    LRnd := TSecureRandom.Create();
+    LSigner := TSignerUtilities.InitSigner(EcdsaMechanism(AAlg), True, AKey, LRnd);
+    LSigner.BlockUpdate(AInput, 0, Length(AInput));
+    Result := TBytes(LSigner.GenerateSignature());
+  except
+    on E: ESignException do
+      raise;
+    on E: Exception do
+      raise ESignException.Create('[CryptoLib] ECDSA sign error: ' + E.Message);
+  end;
+end;
+
+function TCryptoLibECDSAProvider.VerifyWithEc(const AInput, ASignature: TBytes; const AKey: IAsymmetricKeyParameter; AAlg: TECDSAAlgorithm): Boolean;
+var
+  LSigner: ISigner;
+begin
+  Result := False;
+  try
+    EnsureNamedCurve(AKey, AAlg);
+    LSigner := TSignerUtilities.InitSigner(EcdsaMechanism(AAlg), False, AKey, nil);
+    LSigner.BlockUpdate(AInput, 0, Length(AInput));
+    Result := LSigner.VerifySignature(ASignature);
+  except
+    Result := False;
+  end;
+end;
+
+function TCryptoLibECDSAProvider.Sign(const AInput, APrivateKey: TBytes; AAlg: TECDSAAlgorithm): TBytes;
+var
+  LPriv: IAsymmetricKeyParameter;
+begin
+  LPriv := PemToPrivateKey(APrivateKey);
+  Result := SignWithEc(AInput, LPriv, AAlg);
+end;
+
+function TCryptoLibECDSAProvider.Verify(const AInput, ASignature, APublicKey: TBytes; AAlg: TECDSAAlgorithm): Boolean;
+var
+  LPub: IAsymmetricKeyParameter;
+begin
+  Result := False;
+  try
+    LPub := PemToPublicKey(APublicKey);
+    Result := VerifyWithEc(AInput, ASignature, LPub, AAlg);
+  except
+    Result := False;
+  end;
+end;
+
+function TCryptoLibECDSAProvider.VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TECDSAAlgorithm): Boolean;
+var
+  LPub: IAsymmetricKeyParameter;
+begin
+  Result := False;
+  try
+    LPub := PemToPublicKey(ACertificate);
+    Result := VerifyWithEc(AInput, ASignature, LPub, AAlg);
+  except
+    Result := False;
+  end;
+end;
+
+function TCryptoLibECDSAProvider.VerifyPublicKey(const AKey: TBytes): Boolean;
+begin
+  try
+    PemToPublicKey(AKey);
+    Result := True;
+  except
+    Result := False;
+  end;
+end;
+
+function TCryptoLibECDSAProvider.VerifyPrivateKey(const AKey: TBytes): Boolean;
+begin
+  try
+    PemToPrivateKey(AKey);
+    Result := True;
+  except
+    Result := False;
+  end;
+end;
+
+{ TJOSECryptoLibProviders }
+
+class procedure TJOSECryptoLibProviders.Register;
+var
+  LCert: IJOSECertificateProvider;
+begin
+  TJOSEProviders.Base64 := TCryptoLibBase64Provider.Create;
+  TJOSEProviders.HMAC := TCryptoLibHmacProvider.Create;
+  LCert := TCryptoLibCertificateProvider.Create;
+  TJOSEProviders.Certificate := LCert;
+  TJOSEProviders.RSA := TCryptoLibRSAProvider.Create(LCert);
+  TJOSEProviders.ECDSA := TCryptoLibECDSAProvider.Create(LCert);
+end;
+
+class procedure TJOSECryptoLibProviders.Unregister;
+begin
+  TJOSEProviders.Base64 := nil;
+  TJOSEProviders.HMAC := nil;
+  TJOSEProviders.Certificate := nil;
+  TJOSEProviders.RSA := nil;
+  TJOSEProviders.ECDSA := nil;
+end;
+
+end.

--- a/Source/Common/JOSE.Providers.CryptoLib.pas
+++ b/Source/Common/JOSE.Providers.CryptoLib.pas
@@ -31,7 +31,8 @@ uses
   JOSE.Types.Bytes,
   JOSE.Providers.Interfaces,
   JOSE.Crypto.Algorithms,
-  ClpIAsymmetricKeyParameter;
+  ClpIAsymmetricKeyParameter,
+  ClpIAsn1Objects;
 
 type
   TCryptoLibBase64Provider = class(TInterfacedObject, IJOSEBase64Provider)
@@ -45,18 +46,23 @@ type
   end;
 
   TCryptoLibHmacProvider = class(TInterfacedObject, IJOSEHmacProvider)
+  strict private
+    function HmacMechanism(AAlg: THMACAlgorithm): string;
   public
     function Sign(const AInput, AKey: TBytes; AAlg: THMACAlgorithm): TBytes;
   end;
 
   TCryptoLibCertificateProvider = class(TInterfacedObject, IJOSECertificateProvider)
+  strict private
+    function ExpectedCertPkAlg(AExpected: TJOSECertificatePublicKey): IDerObjectIdentifier;
+    function WritePublicKeyPem(const APublicKey: IAsymmetricKeyParameter): TBytes;
   public
     function PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
     function VerifyCertificate(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): Boolean;
   end;
 
   TCryptoLibRSAProvider = class(TInterfacedObject, IJOSESignerRSA)
-  private
+  strict private
     FCertificate: IJOSECertificateProvider;
     function PemToPublicKey(const APem: TBytes): IAsymmetricKeyParameter;
     function PemToPrivateKey(const APem: TBytes): IAsymmetricKeyParameter;
@@ -73,8 +79,9 @@ type
   end;
 
   TCryptoLibECDSAProvider = class(TInterfacedObject, IJOSESignerECDSA)
-  private
+  strict private
     FCertificate: IJOSECertificateProvider;
+    function ExpectedEcCurveOid(AAlg: TECDSAAlgorithm): IDerObjectIdentifier;
     procedure EnsureNamedCurve(const AKey: IAsymmetricKeyParameter; AAlg: TECDSAAlgorithm);
     function EcdsaMechanism(AAlg: TECDSAAlgorithm): string;
     function PemToPublicKey(const APem: TBytes): IAsymmetricKeyParameter;
@@ -118,7 +125,6 @@ uses
   ClpIX509CertificateParser,
   ClpIX509Certificate,
   ClpIAsymmetricCipherKeyPair,
-  ClpIAsn1Objects,
   ClpIX509Asn1Objects,
   ClpPkcsObjectIdentifiers,
   ClpX9ObjectIdentifiers,
@@ -202,7 +208,7 @@ end;
 
 { TCryptoLibHmacProvider }
 
-function HmacMechanism(AAlg: THMACAlgorithm): string;
+function TCryptoLibHmacProvider.HmacMechanism(AAlg: THMACAlgorithm): string;
 begin
   case AAlg of
     THMACAlgorithm.SHA256:
@@ -345,7 +351,7 @@ end;
 
 { TCryptoLibCertificateProvider }
 
-function ExpectedCertPkAlg(AExpected: TJOSECertificatePublicKey): IDerObjectIdentifier;
+function TCryptoLibCertificateProvider.ExpectedCertPkAlg(AExpected: TJOSECertificatePublicKey): IDerObjectIdentifier;
 begin
   case AExpected of
     TJOSECertificatePublicKey.RSA:
@@ -357,7 +363,7 @@ begin
   end;
 end;
 
-function WritePublicKeyPem(const APublicKey: IAsymmetricKeyParameter): TBytes;
+function TCryptoLibCertificateProvider.WritePublicKeyPem(const APublicKey: IAsymmetricKeyParameter): TBytes;
 var
   LStream: TMemoryStream;
   LWriter: TOpenSslPemWriter;
@@ -545,7 +551,7 @@ begin
   FCertificate := ACertificate;
 end;
 
-function ExpectedEcCurveOid(AAlg: TECDSAAlgorithm): IDerObjectIdentifier;
+function TCryptoLibECDSAProvider.ExpectedEcCurveOid(AAlg: TECDSAAlgorithm): IDerObjectIdentifier;
 begin
   case AAlg of
     TECDSAAlgorithm.ES256:

--- a/Source/Common/JOSE.Providers.Default.pas
+++ b/Source/Common/JOSE.Providers.Default.pas
@@ -542,8 +542,6 @@ function TDefaultRSAProvider.VerifyWithCertificate(const AInput, ASignature, ACe
 var
   LRsa: PRSA;
 begin
-  TJOSEDefaultOpenSslPem.LoadOpenSSL;
-
   LRsa := LoadRSAPublicKeyFromCert(ACertificate);
   try
     Result := InternalVerify(AInput, ASignature, LRsa, AAlg);
@@ -614,8 +612,6 @@ var
   LSig: PECDSA_SIG;
   LShaHash: TBytes;
 begin
-  TJOSEDefaultOpenSslPem.LoadOpenSSL;
-
   LECKey := EVP_PKEY_get1_EC_KEY(APublicKey);
   if LECKey = nil then
     raise Exception.Create('[ECDSA] Error getting memory for ECDSA');
@@ -671,7 +667,6 @@ function TDefaultECDSAProvider.Sign(const AInput, APrivateKey: TBytes; AAlg: TEC
 var
   LKey: PEVP_PKEY;
 begin
-  TJOSEDefaultOpenSslPem.LoadOpenSSL;
   Result := [];
 
   LKey := LoadPrivateKey(APrivateKey);
@@ -688,8 +683,6 @@ var
   LSig: PECDSA_SIG;
   LShaHash: TBytes;
 begin
-  TJOSEDefaultOpenSslPem.LoadOpenSSL;
-
   Result := [];
   LECKey := EVP_PKEY_get1_EC_KEY(AKey);
   if LECKey = nil then
@@ -748,8 +741,6 @@ function TDefaultECDSAProvider.Verify(const AInput, ASignature, APublicKey: TByt
 var
   LPubKey: PEVP_PKEY;
 begin
-  TJOSEDefaultOpenSslPem.LoadOpenSSL;
-
   LPubKey := LoadPublicKey(APublicKey);
   try
     Result := InternalVerify(AInput, ASignature, LPubKey, AAlg);
@@ -801,8 +792,6 @@ function TDefaultECDSAProvider.VerifyWithCertificate(const AInput, ASignature, A
 var
   LKey: PEVP_PKEY;
 begin
-  TJOSEDefaultOpenSslPem.LoadOpenSSL;
-
   LKey := LoadPublicKeyFromCert(ACertificate, TJOSECertificatePublicKey.EC);
   try
     Result := InternalVerify(AInput, ASignature, LKey, AAlg);
@@ -940,9 +929,16 @@ begin
 end;
 
 function TDefaultBase64Provider.InternalEncode(const ASource: TJOSEBytes): TJOSEBytes;
+var
+  LEnc: TBase64Encoding;
 begin
   {$IF CompilerVersion >= 28}
-  Result := TNetEncoding.Base64.Encode(ASource.AsBytes);
+  LEnc := TBase64Encoding.Create(0);
+  try
+    Result := LEnc.Encode(ASource.AsBytes);
+  finally
+    LEnc.Free;
+  end;
   {$ELSE}
   Result := EncodeBase64(ASource.AsBytes);
   {$IFEND}

--- a/Source/Common/JOSE.Providers.Default.pas
+++ b/Source/Common/JOSE.Providers.Default.pas
@@ -1,0 +1,1048 @@
+{******************************************************************************}
+{                                                                              }
+{  Delphi JOSE Library                                                         }
+{  Copyright (c) 2015 Paolo Rossi                                              }
+{  https://github.com/paolo-rossi/delphi-jose-jwt                              }
+{                                                                              }
+{******************************************************************************}
+{                                                                              }
+{  Licensed under the Apache License, Version 2.0 (the "License");             }
+{  you may not use this file except in compliance with the License.            }
+{  You may obtain a copy of the License at                                     }
+{                                                                              }
+{      http://www.apache.org/licenses/LICENSE-2.0                              }
+{                                                                              }
+{  Unless required by applicable law or agreed to in writing, software         }
+{  distributed under the License is distributed on an "AS IS" BASIS,           }
+{  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    }
+{  See the License for the specific language governing permissions and         }
+{  limitations under the License.                                              }
+{                                                                              }
+{******************************************************************************}
+
+unit JOSE.Providers.Default;
+
+{$I ..\JOSE.inc}
+
+interface
+
+uses
+  System.SysUtils,
+  JOSE.Types.Bytes,
+  JOSE.Crypto.Algorithms,
+  JOSE.Providers.Interfaces
+{$IFDEF RSA_SIGNING}
+  , IdGlobal, IdCTypes, IdSSLOpenSSLHeaders
+{$ENDIF};
+
+type
+  TDefaultBase64Provider = class(TInterfacedObject, IJOSEBase64Provider)
+  private
+    function InternalEncode(const ASource: TJOSEBytes): TJOSEBytes;
+    function InternalDecode(const ASource: TJOSEBytes): TJOSEBytes;
+  public
+    function Encode(const ASource: TJOSEBytes): TJOSEBytes;
+    function Decode(const ASource: TJOSEBytes): TJOSEBytes;
+    function TryDecode(const ASource: TJOSEBytes): TJOSEBytes;
+    function URLEncode(const ASource: TJOSEBytes): TJOSEBytes;
+    function URLDecode(const ASource: TJOSEBytes): TJOSEBytes;
+    function TryURLDecode(const ASource: TJOSEBytes): TJOSEBytes;
+  end;
+
+  TDefaultHmacProvider = class(TInterfacedObject, IJOSEHmacProvider)
+  public
+    function Sign(const AInput, AKey: TBytes; AAlg: THMACAlgorithm): TBytes;
+  end;
+
+{$IFDEF RSA_SIGNING}
+
+  TDefaultCertificateProvider = class(TInterfacedObject, IJOSECertificateProvider)
+  public
+    function PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
+    function VerifyCertificate(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): Boolean;
+  end;
+
+  TDefaultRSAProvider = class(TInterfacedObject, IJOSESignerRSA)
+  private
+    FCertificate: IJOSECertificateProvider;
+    class function RSAKeyFromEVP(AKey: PEVP_PKEY): PRSA;
+    function LoadPublicKey(const AKey: TBytes): PRSA;
+    function LoadPrivateKey(const AKey: TBytes): PRSA;
+    function LoadRSAPublicKeyFromCert(const ACertificate: TBytes): PRSA;
+    function InternalSign(const AInput: TBytes; AKey: PRSA; AAlg: TRSAAlgorithm): TBytes;
+    function InternalVerify(const AInput, ASignature: TBytes; AKey: PRSA; AAlg: TRSAAlgorithm): Boolean;
+    class function StartsWith(const ABuf, APrefix: TBytes): Boolean; static;
+  public
+    constructor Create(ACertificate: IJOSECertificateProvider);
+    function Sign(const AInput, AKey: TBytes; AAlg: TRSAAlgorithm): TBytes;
+    function Verify(const AInput, ASignature, AKey: TBytes; AAlg: TRSAAlgorithm): Boolean;
+    function VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TRSAAlgorithm): Boolean;
+    function VerifyPublicKey(const AKey: TBytes): Boolean;
+    function VerifyPrivateKey(const AKey: TBytes): Boolean;
+  end;
+
+  TDefaultECDSAProvider = class(TInterfacedObject, IJOSESignerECDSA)
+  private
+    function LoadPublicKey(const AKey: TBytes): PEVP_PKEY;
+    function LoadPrivateKey(const AKey: TBytes): PEVP_PKEY;
+    function LoadPublicKeyFromCert(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): PEVP_PKEY;
+    function InternalSign(const AInput: TBytes; AKey: PEVP_PKEY; AAlg: TECDSAAlgorithm): TBytes;
+    function InternalVerify(const AInput, ASignature: TBytes; APublicKey: PEVP_PKEY; AAlg: TECDSAAlgorithm): Boolean;
+    function HashFromBytes(const AInput: TBytes; AAlg: TECDSAAlgorithm): TBytes;
+    function Sig2OctetSequence(ASignature: PECDSA_SIG; AAlg: TECDSAAlgorithm): TBytes;
+    function OctetSequence2Sig(const ASignature: TBytes; AAlg: TECDSAAlgorithm): PECDSA_SIG;
+  public
+    function Sign(const AInput, APrivateKey: TBytes; AAlg: TECDSAAlgorithm): TBytes;
+    function Verify(const AInput, ASignature, APublicKey: TBytes; AAlg: TECDSAAlgorithm): Boolean;
+    function VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TECDSAAlgorithm): Boolean;
+    function VerifyPublicKey(const AKey: TBytes): Boolean;
+    function VerifyPrivateKey(const AKey: TBytes): Boolean;
+  end;
+
+{$ENDIF}
+
+implementation
+
+uses
+{$IFDEF RSA_SIGNING}
+  System.StrUtils,
+  JOSE.Signing.Base,
+  JOSE.Types.Utils,
+  JOSE.OpenSSL.Headers,
+{$ENDIF}
+  {$IF CompilerVersion >= 28}
+  System.NetEncoding,
+  {$IFEND}
+  {$IF CompilerVersion < 30 }
+  {$IFNDEF RSA_SIGNING}
+  IdGlobal,
+  {$ENDIF}
+  IdHMAC,
+  IdHMACSHA1,
+  IdSSLOpenSSL,
+  IdHash,
+  {$IFEND}
+  {$IF CompilerVersion >= 30 }
+  System.Hash,
+  {$IFEND}
+  System.Types;
+
+{$IFDEF RSA_SIGNING}
+
+function JoseExpectedNidForCertPublicKey(const AExpected: TJOSECertificatePublicKey): Integer;
+begin
+  case AExpected of
+    TJOSECertificatePublicKey.RSA:
+      Result := NID_rsaEncryption;
+    TJOSECertificatePublicKey.EC:
+      Result := JoseSSL.NID_X9_62_id_ecPublicKey;
+  else
+    raise EArgumentException.Create('Unhandled TJOSECertificatePublicKey value');
+  end;
+end;
+
+type
+  TJOSEDefaultOpenSslPem = class
+  strict private
+    class var
+      FPEM_X509_CERTIFICATE: TBytes;
+      FPEM_PUBKEY_PKCS1: TBytes;
+      FPEM_PUBKEY: TBytes;
+      FPEM_PRVKEY_PKCS8: TBytes;
+      FPEM_PRVKEY_PKCS1: TBytes;
+    class constructor Create;
+  public
+    class procedure LoadOpenSSL;
+    class function LoadCertificate(const ACertificate: TBytes): PX509;
+    class function LoadPublicKeyFromCert(const ACertificate: TBytes): PEVP_PKEY; overload;
+    class function LoadPublicKeyFromCert(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): PEVP_PKEY; overload;
+    class function PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
+    class function VerifyCertificate(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): Boolean;
+    class property PEM_X509_CERTIFICATE: TBytes read FPEM_X509_CERTIFICATE;
+    class property PEM_PUBKEY_PKCS1: TBytes read FPEM_PUBKEY_PKCS1;
+  end;
+
+class constructor TJOSEDefaultOpenSslPem.Create;
+begin
+  FPEM_X509_CERTIFICATE := TEncoding.ASCII.GetBytes('-----BEGIN CERTIFICATE-----');
+  FPEM_PUBKEY_PKCS1 := TEncoding.ASCII.GetBytes('-----BEGIN RSA PUBLIC KEY-----');
+  FPEM_PUBKEY := TEncoding.ASCII.GetBytes('-----BEGIN PUBLIC KEY-----');
+  FPEM_PRVKEY_PKCS8 := TEncoding.ASCII.GetBytes('-----BEGIN PRIVATE KEY-----');
+  FPEM_PRVKEY_PKCS1 := TEncoding.ASCII.GetBytes('-----BEGIN EC PRIVATE KEY-----');
+end;
+
+class procedure TJOSEDefaultOpenSslPem.LoadOpenSSL;
+begin
+  if not IdSSLOpenSSLHeaders.Load then
+    raise ESignException.Create('[OpenSSL] Unable to load OpenSSL libraries');
+
+  if not JoseSSL.Load then
+    raise ESignException.Create('[OpenSSL] Unable to load OpenSSL libraries');
+
+  if @EVP_DigestVerifyInit = nil then
+    raise ESignException.Create('[OpenSSL] Please, use OpenSSL 1.0.0 or newer!');
+end;
+
+class function TJOSEDefaultOpenSslPem.LoadCertificate(const ACertificate: TBytes): PX509;
+var
+  LBio: PBIO;
+begin
+  if not CompareMem(@FPEM_X509_CERTIFICATE[0], @ACertificate[0], Length(FPEM_X509_CERTIFICATE)) then
+    raise ESignException.Create('[OpenSSL] Not a valid X509 certificate');
+
+  LBio := BIO_new(BIO_s_mem);
+  try
+    BIO_write(LBio, @ACertificate[0], Length(ACertificate));
+    Result := PEM_read_bio_X509(LBio, nil, nil, nil);
+    if Result = nil then
+      raise ESignException.Create('[OpenSSL] Error loading X509 certificate');
+  finally
+    BIO_free(LBio);
+  end;
+end;
+
+class function TJOSEDefaultOpenSslPem.LoadPublicKeyFromCert(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): PEVP_PKEY;
+var
+  LCer: PX509;
+  LAlg: Integer;
+  LExpectedNid: Integer;
+begin
+{$IF CompilerVersion < 33 }
+  Result := nil;
+{$IFEND}
+  LoadOpenSSL;
+
+  LCer := LoadCertificate(ACertificate);
+  try
+    LAlg := OBJ_obj2nid(LCer.cert_info.key.algor.algorithm);
+    LExpectedNid := JoseExpectedNidForCertPublicKey(AExpected);
+    if LAlg <> LExpectedNid then
+      raise ESignException.Create('[OpenSSL] Certificate public key algorithm does not match expected type');
+
+    Result := X509_PUBKEY_get(LCer.cert_info.key);
+    if not Assigned(Result) then
+      raise ESignException.Create('[OpenSSL] Error extracting public key from X509 certificate');
+  finally
+    X509_free(LCer);
+  end;
+end;
+
+class function TJOSEDefaultOpenSslPem.LoadPublicKeyFromCert(const ACertificate: TBytes): PEVP_PKEY;
+var
+  LCer: PX509;
+begin
+  LoadOpenSSL;
+
+  LCer := LoadCertificate(ACertificate);
+  try
+    Result := X509_PUBKEY_get(LCer.cert_info.key);
+    if not Assigned(Result) then
+      raise ESignException.Create('[OpenSSL] Error extracting public key from X509 certificate');
+  finally
+    X509_free(LCer);
+  end;
+end;
+
+class function TJOSEDefaultOpenSslPem.PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
+var
+  LKey: PEVP_PKEY;
+  LBio: PBIO;
+  LBuffer: TBytes;
+  LBytesRead: Integer;
+begin
+  LKey := LoadPublicKeyFromCert(ACertificate);
+  try
+    LBio := BIO_new(BIO_s_mem);
+    try
+      JoseSSL.PEM_write_bio_PUBKEY(LBio, LKey);
+
+      Result := [];
+      SetLength(LBuffer, 255);
+      repeat
+        LBytesRead := BIO_read(LBio, @LBuffer[0], 255);
+        TJOSEUtils.ArrayPush(LBuffer, Result, LBytesRead);
+      until (LBytesRead <= 0);
+    finally
+      BIO_free(LBio);
+    end;
+  finally
+    EVP_PKEY_free(LKey);
+  end;
+end;
+
+class function TJOSEDefaultOpenSslPem.VerifyCertificate(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): Boolean;
+var
+  LCer: PX509;
+  LKey: PEVP_PKEY;
+  LAlg: Integer;
+  LExpectedNid: Integer;
+begin
+  LoadOpenSSL;
+
+  LCer := LoadCertificate(ACertificate);
+  try
+    LKey := X509_PUBKEY_get(LCer.cert_info.key);
+    try
+      LAlg := OBJ_obj2nid(LCer.cert_info.key.algor.algorithm);
+      LExpectedNid := JoseExpectedNidForCertPublicKey(AExpected);
+      Result := Assigned(LCer) and Assigned(LKey) and (LAlg = LExpectedNid);
+    finally
+      EVP_PKEY_free(LKey);
+    end;
+  finally
+    X509_free(LCer);
+  end;
+end;
+
+{ TDefaultCertificateProvider }
+
+function TDefaultCertificateProvider.PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
+begin
+  Result := TJOSEDefaultOpenSslPem.PublicKeyFromCertificate(ACertificate);
+end;
+
+function TDefaultCertificateProvider.VerifyCertificate(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): Boolean;
+begin
+  Result := TJOSEDefaultOpenSslPem.VerifyCertificate(ACertificate, AExpected);
+end;
+
+{ TDefaultRSAProvider }
+
+constructor TDefaultRSAProvider.Create(ACertificate: IJOSECertificateProvider);
+begin
+  inherited Create;
+  FCertificate := ACertificate;
+end;
+
+class function TDefaultRSAProvider.StartsWith(const ABuf, APrefix: TBytes): Boolean;
+begin
+  Result := (Length(ABuf) >= Length(APrefix)) and CompareMem(@APrefix[0], @ABuf[0], Length(APrefix));
+end;
+
+class function TDefaultRSAProvider.RSAKeyFromEVP(AKey: PEVP_PKEY): PRSA;
+begin
+  Result := EVP_PKEY_get1_RSA(AKey);
+  if not Assigned(Result) then
+    raise ESignException.Create('[RSA] Error extracting RSA key from EVP_PKEY');
+end;
+
+function TDefaultRSAProvider.InternalSign(const AInput: TBytes; AKey: PRSA; AAlg: TRSAAlgorithm): TBytes;
+var
+  LHash: TBytes;
+  LNID: Integer;
+  LRsaLen: Integer;
+  LShaLen: Integer;
+begin
+  case AAlg of
+    RS256:
+    begin
+      LNID := JoseSSL.NID_sha256;
+      LShaLen := SHA256_DIGEST_LENGTH;
+      SetLength(LHash, LShaLen);
+      JoseSSL.SHA256(@AInput[0], Length(AInput), @LHash[0]);
+    end;
+    RS384:
+    begin
+      LNID := JoseSSL.NID_sha384;
+      LShaLen := SHA384_DIGEST_LENGTH;
+      SetLength(LHash, LShaLen);
+      JoseSSL.SHA384(@AInput[0], Length(AInput), @LHash[0]);
+    end;
+    RS512:
+    begin
+      LNID := JoseSSL.NID_sha512;
+      LShaLen := SHA512_DIGEST_LENGTH;
+      SetLength(LHash, LShaLen);
+      JoseSSL.SHA512(@AInput[0], Length(AInput), @LHash[0]);
+    end;
+  else
+    raise ESignException.Create('[RSA] Unsupported signing algorithm!');
+  end;
+
+  LRsaLen := JoseSSL.RSA_size(AKey);
+  SetLength(Result, LRsaLen);
+  if JoseSSL.RSA_sign(LNID, @LHash[0], LShaLen, @Result[0], @LRsaLen, AKey) = 0 then
+    raise ESignException.Create('[RSA] Unable to sign RSA message digest');
+end;
+
+function TDefaultRSAProvider.InternalVerify(const AInput, ASignature: TBytes; AKey: PRSA; AAlg: TRSAAlgorithm): Boolean;
+var
+  LResult: Integer;
+  LHash: TBytes;
+  LNID: Integer;
+  LShaLen: Integer;
+begin
+  case AAlg of
+    RS256:
+    begin
+      LNID := JoseSSL.NID_sha256;
+      LShaLen := SHA256_DIGEST_LENGTH;
+      SetLength(LHash, LShaLen);
+      JoseSSL.SHA256(@AInput[0], Length(AInput), @LHash[0]);
+    end;
+    RS384:
+    begin
+      LNID := JoseSSL.NID_sha384;
+      LShaLen := SHA384_DIGEST_LENGTH;
+      SetLength(LHash, LShaLen);
+      JoseSSL.SHA384(@AInput[0], Length(AInput), @LHash[0]);
+    end;
+    RS512:
+    begin
+      LNID := JoseSSL.NID_sha512;
+      LShaLen := SHA512_DIGEST_LENGTH;
+      SetLength(LHash, LShaLen);
+      JoseSSL.SHA512(@AInput[0], Length(AInput), @LHash[0]);
+    end;
+  else
+    raise ESignException.Create('[RSA] Unsupported signing algorithm!');
+  end;
+  LResult := JoseSSL.RSA_verify(LNID, @LHash[0], LShaLen, @ASignature[0], Length(ASignature), AKey);
+
+  Result := LResult = 1;
+end;
+
+function TDefaultRSAProvider.LoadPrivateKey(const AKey: TBytes): PRSA;
+var
+  LBio: PBIO;
+begin
+  LBio := BIO_new(BIO_s_mem);
+  try
+    BIO_write(LBio, @AKey[0], Length(AKey));
+    Result := PEM_read_bio_RSAPrivateKey(LBio, nil, nil, nil);
+    if Result = nil then
+      raise ESignException.Create('[RSA] Unable to load private key: ' + JoseSSL.GetLastError);
+  finally
+    BIO_free(LBio);
+  end;
+end;
+
+function TDefaultRSAProvider.LoadPublicKey(const AKey: TBytes): PRSA;
+var
+  LBio: PBIO;
+  LPubKey: TBytes;
+begin
+  LBio := BIO_new(BIO_s_mem);
+  try
+    if StartsWith(AKey, TJOSEDefaultOpenSslPem.PEM_X509_CERTIFICATE) then
+    begin
+      LPubKey := FCertificate.PublicKeyFromCertificate(AKey);
+      BIO_write(LBio, @LPubKey[0], Length(LPubKey));
+      Result := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
+    end
+    else
+    begin
+      BIO_write(LBio, @AKey[0], Length(AKey));
+      if StartsWith(AKey, TJOSEDefaultOpenSslPem.PEM_PUBKEY_PKCS1) then
+        Result := PEM_read_bio_RSAPublicKey(LBio, nil, nil, nil)
+      else
+        Result := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
+    end;
+
+    if Result = nil then
+      raise ESignException.Create('[RSA] Unable to load public key: ' + JoseSSL.GetLastError);
+  finally
+    BIO_free(LBio);
+  end;
+end;
+
+function TDefaultRSAProvider.LoadRSAPublicKeyFromCert(const ACertificate: TBytes): PRSA;
+var
+  LKey: PEVP_PKEY;
+begin
+  LKey := TJOSEDefaultOpenSslPem.LoadPublicKeyFromCert(ACertificate, TJOSECertificatePublicKey.RSA);
+  try
+    Result := RSAKeyFromEVP(LKey);
+  finally
+    EVP_PKEY_free(LKey);
+  end;
+end;
+
+function TDefaultRSAProvider.Sign(const AInput, AKey: TBytes; AAlg: TRSAAlgorithm): TBytes;
+var
+  LRsa: PRSA;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LRsa := LoadPrivateKey(AKey);
+  try
+    Result := InternalSign(AInput, LRsa, AAlg);
+  finally
+    RSA_Free(LRsa);
+  end;
+end;
+
+function TDefaultRSAProvider.Verify(const AInput, ASignature, AKey: TBytes; AAlg: TRSAAlgorithm): Boolean;
+var
+  LRsa: PRSA;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LRsa := LoadPublicKey(AKey);
+  try
+    Result := InternalVerify(AInput, ASignature, LRsa, AAlg);
+  finally
+    RSA_Free(LRsa);
+  end;
+end;
+
+function TDefaultRSAProvider.VerifyPrivateKey(const AKey: TBytes): Boolean;
+var
+  LBio: PBIO;
+  LRsa: PRSA;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LBio := BIO_new(BIO_s_mem);
+  try
+    BIO_write(LBio, @AKey[0], Length(AKey));
+    LRsa := PEM_read_bio_RSAPrivateKey(LBio, nil, nil, nil);
+    Result := (LRsa <> nil);
+    if Result then
+      RSA_Free(LRsa);
+  finally
+    BIO_free(LBio);
+  end;
+end;
+
+function TDefaultRSAProvider.VerifyPublicKey(const AKey: TBytes): Boolean;
+var
+  LBio: PBIO;
+  LRsa: PRSA;
+  LPubKey: TBytes;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LBio := BIO_new(BIO_s_mem);
+  try
+    if StartsWith(AKey, TJOSEDefaultOpenSslPem.PEM_X509_CERTIFICATE) then
+    begin
+      LPubKey := FCertificate.PublicKeyFromCertificate(AKey);
+      BIO_write(LBio, @LPubKey[0], Length(LPubKey));
+      LRsa := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
+    end
+    else
+    begin
+      BIO_write(LBio, @AKey[0], Length(AKey));
+      if StartsWith(AKey, TJOSEDefaultOpenSslPem.PEM_PUBKEY_PKCS1) then
+        LRsa := PEM_read_bio_RSAPublicKey(LBio, nil, nil, nil)
+      else
+        LRsa := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
+    end;
+
+    Result := (LRsa <> nil);
+    if Result then
+      RSA_Free(LRsa);
+  finally
+    BIO_free(LBio);
+  end;
+end;
+
+function TDefaultRSAProvider.VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TRSAAlgorithm): Boolean;
+var
+  LRsa: PRSA;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LRsa := LoadRSAPublicKeyFromCert(ACertificate);
+  try
+    Result := InternalVerify(AInput, ASignature, LRsa, AAlg);
+  finally
+    RSA_free(LRsa);
+  end;
+end;
+
+{ TDefaultECDSAProvider }
+
+function TDefaultECDSAProvider.LoadPublicKeyFromCert(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): PEVP_PKEY;
+var
+  LCer: PX509;
+  LAlg: Integer;
+  LExpectedNid: Integer;
+begin
+{$IF CompilerVersion < 33 }
+  Result := nil;
+{$IFEND}
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LCer := TJOSEDefaultOpenSslPem.LoadCertificate(ACertificate);
+  try
+    LAlg := OBJ_obj2nid(LCer.cert_info.key.algor.algorithm);
+    LExpectedNid := JoseExpectedNidForCertPublicKey(AExpected);
+    if LAlg <> LExpectedNid then
+      raise ESignException.Create('[OpenSSL] Certificate public key algorithm does not match expected type');
+
+    Result := X509_PUBKEY_get(LCer.cert_info.key);
+    if not Assigned(Result) then
+      raise ESignException.Create('[OpenSSL] Error extracting public key from X509 certificate');
+  finally
+    X509_free(LCer);
+  end;
+end;
+
+function TDefaultECDSAProvider.HashFromBytes(const AInput: TBytes; AAlg: TECDSAAlgorithm): TBytes;
+var
+  LShaLen: Integer;
+begin
+  case AAlg of
+    ES256, ES256K:
+    begin
+      LShaLen := SHA256_DIGEST_LENGTH;
+      SetLength(Result, LShaLen);
+      JoseSSL.SHA256(@AInput[0], Length(AInput), @Result[0]);
+    end;
+    ES384:
+    begin
+      LShaLen := SHA384_DIGEST_LENGTH;
+      SetLength(Result, LShaLen);
+      JoseSSL.SHA384(@AInput[0], Length(AInput), @Result[0]);
+    end;
+    ES512:
+    begin
+      LShaLen := SHA512_DIGEST_LENGTH;
+      SetLength(Result, LShaLen);
+      JoseSSL.SHA512(@AInput[0], Length(AInput), @Result[0]);
+    end;
+  else
+    raise Exception.Create('[ECDSA] Unsupported signing algorithm!');
+  end;
+end;
+
+function TDefaultECDSAProvider.InternalVerify(const AInput, ASignature: TBytes; APublicKey: PEVP_PKEY; AAlg: TECDSAAlgorithm): Boolean;
+var
+  LECKey: PEC_KEY;
+  LSig: PECDSA_SIG;
+  LShaHash: TBytes;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LECKey := EVP_PKEY_get1_EC_KEY(APublicKey);
+  if LECKey = nil then
+    raise Exception.Create('[ECDSA] Error getting memory for ECDSA');
+  try
+    LSig := OctetSequence2Sig(ASignature, AAlg);
+    try
+      LShaHash := HashFromBytes(AInput, AAlg);
+      Result := JoseSSL.ECDSA_do_verify(@LShaHash[0], Length(LShaHash), LSig, LECKey) = 1;
+    finally
+      JoseSSL.ECDSA_SIG_free(LSig);
+    end;
+  finally
+    JoseSSL.EC_KEY_free(LECKey);
+  end;
+end;
+
+function TDefaultECDSAProvider.LoadPrivateKey(const AKey: TBytes): PEVP_PKEY;
+var
+  LBIO: PBIO;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LBIO := BIO_new(BIO_s_mem);
+  try
+    BIO_write(LBIO, @AKey[0], Length(AKey));
+    Result := PEM_read_bio_PrivateKey(LBIO, nil, nil, nil);
+    if Result = nil then
+      raise ESignException.Create('[ECDSA] Unable to load private key: ' + JoseSSL.GetLastError);
+  finally
+    BIO_free(LBIO);
+  end;
+end;
+
+function TDefaultECDSAProvider.LoadPublicKey(const AKey: TBytes): PEVP_PKEY;
+var
+  LKeyBuffer: PBIO;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LKeyBuffer := BIO_new(BIO_s_mem);
+  try
+    BIO_write(LKeyBuffer, @AKey[0], Length(AKey));
+
+    Result := JoseSSL.PEM_read_bio_PUBKEY(LKeyBuffer, nil, nil, nil);
+    if Result = nil then
+      raise Exception.Create('[ECDSA] Unable to load public key: ' + JoseSSL.GetLastError);
+  finally
+    BIO_free(LKeyBuffer);
+  end;
+end;
+
+function TDefaultECDSAProvider.Sign(const AInput, APrivateKey: TBytes; AAlg: TECDSAAlgorithm): TBytes;
+var
+  LKey: PEVP_PKEY;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+  Result := [];
+
+  LKey := LoadPrivateKey(APrivateKey);
+  try
+    Result := InternalSign(AInput, LKey, AAlg);
+  finally
+    EVP_PKEY_free(LKey);
+  end;
+end;
+
+function TDefaultECDSAProvider.InternalSign(const AInput: TBytes; AKey: PEVP_PKEY; AAlg: TECDSAAlgorithm): TBytes;
+var
+  LECKey: PEC_KEY;
+  LSig: PECDSA_SIG;
+  LShaHash: TBytes;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  Result := [];
+  LECKey := EVP_PKEY_get1_EC_KEY(AKey);
+  if LECKey = nil then
+    raise ESignException.Create('[ECDSA] Error getting EC Key: ' + JoseSSL.GetLastError);
+  try
+    LShaHash := HashFromBytes(AInput, AAlg);
+
+    LSig := JoseSSL.ECDSA_do_sign(@LShaHash[0], Length(LShaHash), LECKey);
+    if LSig = nil then
+      raise ESignException.Create('[ECDSA] Digest signing failed: ' + JoseSSL.GetLastError);
+    try
+      Result := Sig2OctetSequence(LSig, AAlg);
+    finally
+      JoseSSL.ECDSA_SIG_free(LSig);
+    end;
+  finally
+    JoseSSL.EC_KEY_free(LECKey);
+  end;
+end;
+
+function TDefaultECDSAProvider.OctetSequence2Sig(const ASignature: TBytes; AAlg: TECDSAAlgorithm): PECDSA_SIG;
+var
+  LKeyLength: Integer;
+begin
+  Result := JoseSSL.ECDSA_SIG_new();
+  LKeyLength := Length(ASignature) div 2;
+
+  JoseSSL.BN_bin2bn(Pointer(ASignature), LKeyLength, Result.r);
+  JoseSSL.BN_bin2bn(Pointer(NativeInt(ASignature) + LKeyLength), LKeyLength, Result.s);
+end;
+
+function TDefaultECDSAProvider.Sig2OctetSequence(ASignature: PECDSA_SIG; AAlg: TECDSAAlgorithm): TBytes;
+var
+  LSigLength, LRLength, LSLength: Integer;
+begin
+  LSigLength := 0;
+
+  case AAlg of
+    ES256:  LSigLength := 32 * 2;
+    ES256K: LSigLength := 32 * 2;
+    ES384:  LSigLength := 48 * 2;
+    ES512:  LSigLength := 66 * 2;
+  end;
+
+  LRLength := JoseSSL.BN_num_bytes(ASignature.r);
+  LSLength := JoseSSL.BN_num_bytes(ASignature.s);
+
+  SetLength(Result, LSigLength);
+  FillChar(Result[0], LSigLength, #0);
+
+  JoseSSL.BN_bn2bin(ASignature.r, Pointer(NativeInt(Result) + (LSigLength div 2) - LRLength));
+  JoseSSL.BN_bn2bin(ASignature.s, Pointer(NativeInt(Result) + LSigLength - LSLength));
+end;
+
+function TDefaultECDSAProvider.Verify(const AInput, ASignature, APublicKey: TBytes; AAlg: TECDSAAlgorithm): Boolean;
+var
+  LPubKey: PEVP_PKEY;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LPubKey := LoadPublicKey(APublicKey);
+  try
+    Result := InternalVerify(AInput, ASignature, LPubKey, AAlg);
+  finally
+    EVP_PKEY_free(LPubKey);
+  end;
+end;
+
+function TDefaultECDSAProvider.VerifyPrivateKey(const AKey: TBytes): Boolean;
+var
+  LBio: PBIO;
+  LPrivKey: PEVP_PKEY;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LBio := BIO_new(BIO_s_mem);
+  try
+    BIO_write(LBio, @AKey[0], Length(AKey));
+    LPrivKey := JoseSSL.PEM_read_bio_ECPrivateKey(LBio, nil, nil, nil);
+    Result := (LPrivKey <> nil);
+    if Result then
+      EVP_PKEY_free(LPrivKey);
+  finally
+    BIO_free(LBio);
+  end;
+end;
+
+function TDefaultECDSAProvider.VerifyPublicKey(const AKey: TBytes): Boolean;
+var
+  LBio: PBIO;
+  LKey: PEVP_PKEY;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LBio := BIO_new(BIO_s_mem);
+  try
+    BIO_write(LBio, @AKey[0], Length(AKey));
+    LKey := JoseSSL.PEM_read_bio_PUBKEY(LBio, nil, nil, nil);
+
+    Result := (LKey <> nil);
+    if Result then
+      EVP_PKEY_free(LKey);
+  finally
+    BIO_free(LBio);
+  end;
+end;
+
+function TDefaultECDSAProvider.VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TECDSAAlgorithm): Boolean;
+var
+  LKey: PEVP_PKEY;
+begin
+  TJOSEDefaultOpenSslPem.LoadOpenSSL;
+
+  LKey := LoadPublicKeyFromCert(ACertificate, TJOSECertificatePublicKey.EC);
+  try
+    Result := InternalVerify(AInput, ASignature, LKey, AAlg);
+  finally
+    EVP_PKEY_free(LKey);
+  end;
+end;
+
+{$ENDIF}
+
+{$IF CompilerVersion <= 27}
+type
+  TPacket = packed record
+    case Integer of
+      0: (b0, b1, b2, b3: Byte);
+      1: (i: Integer);
+      2: (a: array[0..3] of Byte);
+  end;
+
+function DecodeBase64(const AInput: string): TBytes;
+const
+  DECODE_TABLE: array[#0..#127] of Integer = (
+    Byte('='), 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
+    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64,
+    64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
+    64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64
+  );
+
+  function DecodePacket(AInputBuffer: PChar; var ANumChars: Integer): TPacket;
+  begin
+    Result.a[0] :=
+      (DECODE_TABLE[AInputBuffer[0]] shl 2) or (DECODE_TABLE[AInputBuffer[1]] shr 4);
+    ANumChars := 1;
+    if AInputBuffer[2] <> '=' then
+    begin
+      Inc(ANumChars);
+      Result.a[1] := (DECODE_TABLE[AInputBuffer[1]] shl 4) or (DECODE_TABLE[AInputBuffer[2]] shr 2);
+    end;
+    if AInputBuffer[3] <> '=' then
+    begin
+      Inc(ANumChars);
+      Result.a[2] := (DECODE_TABLE[AInputBuffer[2]] shl 6) or DECODE_TABLE[AInputBuffer[3]];
+    end;
+  end;
+
+var
+  I, J, K: Integer;
+  LPacket: TPacket;
+  LLen: Integer;
+begin
+  SetLength(Result, Length(AInput) div 4 * 3);
+  LLen := 0;
+  for I := 1 to Length(AInput) div 4 do
+  begin
+    LPacket := DecodePacket(PChar(@AInput[(I - 1) * 4 + 1]), J);
+    K := 0;
+    while J > 0 do
+    begin
+      Result[LLen] := LPacket.a[K];
+      Inc(LLen);
+      Inc(K);
+      Dec(J);
+    end;
+  end;
+  SetLength(Result, LLen);
+end;
+
+function EncodeBase64(const AInput: TBytes): string;
+const
+  ENCODE_TABLE: array[0..63] of Char =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZ' +
+    'abcdefghijklmnopqrstuvwxyz' +
+    '0123456789+/';
+
+  procedure EncodePacket(const APacket: TPacket; ANumChars: Integer; AOutBuffer: PChar);
+  begin
+    AOutBuffer[0] := ENCODE_TABLE[APacket.a[0] shr 2];
+    AOutBuffer[1] := ENCODE_TABLE[((APacket.a[0] shl 4) or (APacket.a[1] shr 4)) and $0000003f];
+
+    if ANumChars < 2 then
+      AOutBuffer[2] := '='
+    else
+      AOutBuffer[2] := ENCODE_TABLE[((APacket.a[1] shl 2) or (APacket.a[2] shr 6)) and $0000003f];
+
+    if ANumChars < 3 then
+      AOutBuffer[3] := '='
+    else
+      AOutBuffer[3] := ENCODE_TABLE[APacket.a[2] and $0000003f];
+  end;
+
+var
+  I, K, J: Integer;
+  LPacket: TPacket;
+begin
+  Result := '';
+  I := (Length(AInput) div 3) * 4;
+  if Length(AInput) mod 3 > 0 then
+    Inc(I, 4);
+  SetLength(Result, I);
+  J := 1;
+  for I := 1 to Length(AInput) div 3 do
+  begin
+    LPacket.i := 0;
+    LPacket.a[0] := AInput[(I - 1) * 3];
+    LPacket.a[1] := AInput[(I - 1) * 3 + 1];
+    LPacket.a[2] := AInput[(I - 1) * 3 + 2];
+    EncodePacket(LPacket, 3, PChar(@Result[J]));
+    Inc(J, 4);
+  end;
+  K := 0;
+  LPacket.i := 0;
+  for I := Length(AInput) - (Length(AInput) mod 3) + 1 to Length(AInput) do
+  begin
+    LPacket.a[K] := Byte(AInput[I - 1]);
+    Inc(K);
+    if I = Length(AInput) then
+      EncodePacket(LPacket, Length(AInput) mod 3, PChar(@Result[J]));
+  end;
+end;
+{$IFEND}
+
+{ TDefaultBase64Provider }
+
+function TDefaultBase64Provider.InternalDecode(const ASource: TJOSEBytes): TJOSEBytes;
+begin
+  {$IF CompilerVersion >= 28}
+  Result := TNetEncoding.Base64.Decode(ASource.AsBytes);
+  {$ELSE}
+  Result := DecodeBase64(ASource.AsString);
+  {$IFEND}
+end;
+
+function TDefaultBase64Provider.InternalEncode(const ASource: TJOSEBytes): TJOSEBytes;
+begin
+  {$IF CompilerVersion >= 28}
+  Result := TNetEncoding.Base64.Encode(ASource.AsBytes);
+  {$ELSE}
+  Result := EncodeBase64(ASource.AsBytes);
+  {$IFEND}
+end;
+
+function TDefaultBase64Provider.Decode(const ASource: TJOSEBytes): TJOSEBytes;
+begin
+  Result := InternalDecode(ASource);
+end;
+
+function TDefaultBase64Provider.Encode(const ASource: TJOSEBytes): TJOSEBytes;
+begin
+  Result := InternalEncode(ASource);
+end;
+
+function TDefaultBase64Provider.TryDecode(const ASource: TJOSEBytes): TJOSEBytes;
+begin
+  try
+    Result := Decode(ASource);
+  except
+    Result.Clear;
+  end;
+end;
+
+function TDefaultBase64Provider.TryURLDecode(const ASource: TJOSEBytes): TJOSEBytes;
+begin
+  try
+    Result := URLDecode(ASource);
+  except
+    Result.Clear;
+  end;
+end;
+
+function TDefaultBase64Provider.URLDecode(const ASource: TJOSEBytes): TJOSEBytes;
+var
+  LBase64Str: string;
+begin
+  LBase64Str := ASource;
+
+  LBase64Str := LBase64Str + StringOfChar('=', (4 - ASource.Size mod 4) mod 4);
+  LBase64Str := StringReplace(LBase64Str, '-', '+', [rfReplaceAll]);
+  LBase64Str := StringReplace(LBase64Str, '_', '/', [rfReplaceAll]);
+  Result := Decode(LBase64Str);
+end;
+
+function TDefaultBase64Provider.URLEncode(const ASource: TJOSEBytes): TJOSEBytes;
+var
+  LBase64Str: string;
+begin
+  LBase64Str := Encode(ASource);
+
+  LBase64Str := StringReplace(LBase64Str, #13#10, '', [rfReplaceAll]);
+  LBase64Str := StringReplace(LBase64Str, #13, '', [rfReplaceAll]);
+  LBase64Str := StringReplace(LBase64Str, #10, '', [rfReplaceAll]);
+  LBase64Str := LBase64Str.TrimRight(['=']);
+
+  LBase64Str := StringReplace(LBase64Str, '+', '-', [rfReplaceAll]);
+  LBase64Str := StringReplace(LBase64Str, '/', '_', [rfReplaceAll]);
+
+  Result := LBase64Str;
+end;
+
+{ TDefaultHmacProvider }
+
+{$IF CompilerVersion >= 30 }
+function TDefaultHmacProvider.Sign(const AInput, AKey: TBytes; AAlg: THMACAlgorithm): TBytes;
+var
+  LHashAlg: THashSHA2.TSHA2Version;
+begin
+  LHashAlg := THashSHA2.TSHA2Version.SHA256;
+  case AAlg of
+    THMACAlgorithm.SHA256: LHashAlg := THashSHA2.TSHA2Version.SHA256;
+    THMACAlgorithm.SHA384: LHashAlg := THashSHA2.TSHA2Version.SHA384;
+    THMACAlgorithm.SHA512: LHashAlg := THashSHA2.TSHA2Version.SHA512;
+  end;
+  Result := THashSHA2.GetHMACAsBytes(AInput, AKey, LHashAlg);
+end;
+{$ELSE}
+function TDefaultHmacProvider.Sign(const AInput, AKey: TBytes; AAlg: THMACAlgorithm): TBytes;
+var
+  LSigner: TIdHMAC;
+begin
+  LSigner := nil;
+
+  if not IdSSLOpenSSL.LoadOpenSSLLibrary then
+    raise Exception.Create('Error Loading OpenSSL libraries');
+
+  case AAlg of
+    THMACAlgorithm.SHA256: LSigner := TIdHMACSHA256.Create;
+    THMACAlgorithm.SHA384: LSigner := TIdHMACSHA384.Create;
+    THMACAlgorithm.SHA512: LSigner := TIdHMACSHA512.Create;
+  end;
+
+  try
+    LSigner.Key := TIdBytes(AKey);
+    Result := TBytes(LSigner.HashValue(TIdBytes(AInput)));
+  finally
+    LSigner.Free;
+  end;
+end;
+{$IFEND}
+
+end.

--- a/Source/Common/JOSE.Providers.Default.pas
+++ b/Source/Common/JOSE.Providers.Default.pas
@@ -80,7 +80,7 @@ type
     function InternalVerify(const AInput, ASignature: TBytes; AKey: PRSA; AAlg: TRSAAlgorithm): Boolean;
     class function StartsWith(const ABuf, APrefix: TBytes): Boolean; static;
   public
-    constructor Create(ACertificate: IJOSECertificateProvider);
+    constructor Create(const ACertificate: IJOSECertificateProvider);
     function Sign(const AInput, AKey: TBytes; AAlg: TRSAAlgorithm): TBytes;
     function Verify(const AInput, ASignature, AKey: TBytes; AAlg: TRSAAlgorithm): Boolean;
     function VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TRSAAlgorithm): Boolean;
@@ -99,7 +99,7 @@ type
     function Sig2OctetSequence(ASignature: PECDSA_SIG; AAlg: TECDSAAlgorithm): TBytes;
     function OctetSequence2Sig(const ASignature: TBytes; AAlg: TECDSAAlgorithm): PECDSA_SIG;
   public
-    constructor Create(ACertificate: IJOSECertificateProvider);
+    constructor Create(const ACertificate: IJOSECertificateProvider);
     function Sign(const AInput, APrivateKey: TBytes; AAlg: TECDSAAlgorithm): TBytes;
     function Verify(const AInput, ASignature, APublicKey: TBytes; AAlg: TECDSAAlgorithm): Boolean;
     function VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TECDSAAlgorithm): Boolean;
@@ -328,7 +328,7 @@ end;
 
 { TDefaultRSAProvider }
 
-constructor TDefaultRSAProvider.Create(ACertificate: IJOSECertificateProvider);
+constructor TDefaultRSAProvider.Create(const ACertificate: IJOSECertificateProvider);
 begin
   inherited Create;
   FCertificate := ACertificate;
@@ -556,7 +556,7 @@ end;
 
 { TDefaultECDSAProvider }
 
-constructor TDefaultECDSAProvider.Create(ACertificate: IJOSECertificateProvider);
+constructor TDefaultECDSAProvider.Create(const ACertificate: IJOSECertificateProvider);
 begin
   inherited Create;
   FCertificate := ACertificate;

--- a/Source/Common/JOSE.Providers.Default.pas
+++ b/Source/Common/JOSE.Providers.Default.pas
@@ -54,6 +54,13 @@ type
     function Sign(const AInput, AKey: TBytes; AAlg: THMACAlgorithm): TBytes;
   end;
 
+  /// <summary>Wires default Delphi/OpenSSL-backed implementations into <c>TJOSEProviders</c>.</summary>
+  TJOSEDefaultProviders = class
+  public
+    class procedure Register; static;
+    class procedure Unregister; static;
+  end;
+
 {$IFDEF RSA_SIGNING}
 
   TDefaultCertificateProvider = class(TInterfacedObject, IJOSECertificateProvider)
@@ -83,15 +90,16 @@ type
 
   TDefaultECDSAProvider = class(TInterfacedObject, IJOSESignerECDSA)
   private
+    FCertificate: IJOSECertificateProvider;
     function LoadPublicKey(const AKey: TBytes): PEVP_PKEY;
     function LoadPrivateKey(const AKey: TBytes): PEVP_PKEY;
-    function LoadPublicKeyFromCert(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): PEVP_PKEY;
     function InternalSign(const AInput: TBytes; AKey: PEVP_PKEY; AAlg: TECDSAAlgorithm): TBytes;
     function InternalVerify(const AInput, ASignature: TBytes; APublicKey: PEVP_PKEY; AAlg: TECDSAAlgorithm): Boolean;
     function HashFromBytes(const AInput: TBytes; AAlg: TECDSAAlgorithm): TBytes;
     function Sig2OctetSequence(ASignature: PECDSA_SIG; AAlg: TECDSAAlgorithm): TBytes;
     function OctetSequence2Sig(const ASignature: TBytes; AAlg: TECDSAAlgorithm): PECDSA_SIG;
   public
+    constructor Create(ACertificate: IJOSECertificateProvider);
     function Sign(const AInput, APrivateKey: TBytes; AAlg: TECDSAAlgorithm): TBytes;
     function Verify(const AInput, ASignature, APublicKey: TBytes; AAlg: TECDSAAlgorithm): Boolean;
     function VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TECDSAAlgorithm): Boolean;
@@ -125,7 +133,8 @@ uses
   {$IF CompilerVersion >= 30 }
   System.Hash,
   {$IFEND}
-  System.Types;
+  System.Types,
+  JOSE.Providers;
 
 {$IFDEF RSA_SIGNING}
 
@@ -156,6 +165,8 @@ type
     class function LoadCertificate(const ACertificate: TBytes): PX509;
     class function LoadPublicKeyFromCert(const ACertificate: TBytes): PEVP_PKEY; overload;
     class function LoadPublicKeyFromCert(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): PEVP_PKEY; overload;
+    /// <summary>SPKI PEM bytes to feed a BIO: certificate PEM yields <c>ACert.PublicKeyFromCertificate</c>, else <c>AKey</c>.</summary>
+    class function PublicKeyPemBytesFromKeyOrCert(const AKey: TBytes; const ACert: IJOSECertificateProvider): TBytes;
     class function PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
     class function VerifyCertificate(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): Boolean;
     class property PEM_X509_CERTIFICATE: TBytes read FPEM_X509_CERTIFICATE;
@@ -241,6 +252,15 @@ begin
   finally
     X509_free(LCer);
   end;
+end;
+
+class function TJOSEDefaultOpenSslPem.PublicKeyPemBytesFromKeyOrCert(const AKey: TBytes; const ACert: IJOSECertificateProvider): TBytes;
+begin
+  if (Length(AKey) >= Length(FPEM_X509_CERTIFICATE)) and
+    CompareMem(@FPEM_X509_CERTIFICATE[0], @AKey[0], Length(FPEM_X509_CERTIFICATE)) then
+    Result := ACert.PublicKeyFromCertificate(AKey)
+  else
+    Result := AKey;
 end;
 
 class function TJOSEDefaultOpenSslPem.PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
@@ -420,24 +440,16 @@ end;
 function TDefaultRSAProvider.LoadPublicKey(const AKey: TBytes): PRSA;
 var
   LBio: PBIO;
-  LPubKey: TBytes;
+  LPem: TBytes;
 begin
   LBio := BIO_new(BIO_s_mem);
   try
-    if StartsWith(AKey, TJOSEDefaultOpenSslPem.PEM_X509_CERTIFICATE) then
-    begin
-      LPubKey := FCertificate.PublicKeyFromCertificate(AKey);
-      BIO_write(LBio, @LPubKey[0], Length(LPubKey));
-      Result := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
-    end
+    LPem := TJOSEDefaultOpenSslPem.PublicKeyPemBytesFromKeyOrCert(AKey, FCertificate);
+    BIO_write(LBio, @LPem[0], Length(LPem));
+    if StartsWith(LPem, TJOSEDefaultOpenSslPem.PEM_PUBKEY_PKCS1) then
+      Result := PEM_read_bio_RSAPublicKey(LBio, nil, nil, nil)
     else
-    begin
-      BIO_write(LBio, @AKey[0], Length(AKey));
-      if StartsWith(AKey, TJOSEDefaultOpenSslPem.PEM_PUBKEY_PKCS1) then
-        Result := PEM_read_bio_RSAPublicKey(LBio, nil, nil, nil)
-      else
-        Result := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
-    end;
+      Result := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
 
     if Result = nil then
       raise ESignException.Create('[RSA] Unable to load public key: ' + JoseSSL.GetLastError);
@@ -509,26 +521,18 @@ function TDefaultRSAProvider.VerifyPublicKey(const AKey: TBytes): Boolean;
 var
   LBio: PBIO;
   LRsa: PRSA;
-  LPubKey: TBytes;
+  LPem: TBytes;
 begin
   TJOSEDefaultOpenSslPem.LoadOpenSSL;
 
   LBio := BIO_new(BIO_s_mem);
   try
-    if StartsWith(AKey, TJOSEDefaultOpenSslPem.PEM_X509_CERTIFICATE) then
-    begin
-      LPubKey := FCertificate.PublicKeyFromCertificate(AKey);
-      BIO_write(LBio, @LPubKey[0], Length(LPubKey));
-      LRsa := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
-    end
+    LPem := TJOSEDefaultOpenSslPem.PublicKeyPemBytesFromKeyOrCert(AKey, FCertificate);
+    BIO_write(LBio, @LPem[0], Length(LPem));
+    if StartsWith(LPem, TJOSEDefaultOpenSslPem.PEM_PUBKEY_PKCS1) then
+      LRsa := PEM_read_bio_RSAPublicKey(LBio, nil, nil, nil)
     else
-    begin
-      BIO_write(LBio, @AKey[0], Length(AKey));
-      if StartsWith(AKey, TJOSEDefaultOpenSslPem.PEM_PUBKEY_PKCS1) then
-        LRsa := PEM_read_bio_RSAPublicKey(LBio, nil, nil, nil)
-      else
-        LRsa := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
-    end;
+      LRsa := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
 
     Result := (LRsa <> nil);
     if Result then
@@ -552,30 +556,10 @@ end;
 
 { TDefaultECDSAProvider }
 
-function TDefaultECDSAProvider.LoadPublicKeyFromCert(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): PEVP_PKEY;
-var
-  LCer: PX509;
-  LAlg: Integer;
-  LExpectedNid: Integer;
+constructor TDefaultECDSAProvider.Create(ACertificate: IJOSECertificateProvider);
 begin
-{$IF CompilerVersion < 33 }
-  Result := nil;
-{$IFEND}
-  TJOSEDefaultOpenSslPem.LoadOpenSSL;
-
-  LCer := TJOSEDefaultOpenSslPem.LoadCertificate(ACertificate);
-  try
-    LAlg := OBJ_obj2nid(LCer.cert_info.key.algor.algorithm);
-    LExpectedNid := JoseExpectedNidForCertPublicKey(AExpected);
-    if LAlg <> LExpectedNid then
-      raise ESignException.Create('[OpenSSL] Certificate public key algorithm does not match expected type');
-
-    Result := X509_PUBKEY_get(LCer.cert_info.key);
-    if not Assigned(Result) then
-      raise ESignException.Create('[OpenSSL] Error extracting public key from X509 certificate');
-  finally
-    X509_free(LCer);
-  end;
+  inherited Create;
+  FCertificate := ACertificate;
 end;
 
 function TDefaultECDSAProvider.HashFromBytes(const AInput: TBytes; AAlg: TECDSAAlgorithm): TBytes;
@@ -648,12 +632,14 @@ end;
 function TDefaultECDSAProvider.LoadPublicKey(const AKey: TBytes): PEVP_PKEY;
 var
   LKeyBuffer: PBIO;
+  LPem: TBytes;
 begin
   TJOSEDefaultOpenSslPem.LoadOpenSSL;
 
   LKeyBuffer := BIO_new(BIO_s_mem);
   try
-    BIO_write(LKeyBuffer, @AKey[0], Length(AKey));
+    LPem := TJOSEDefaultOpenSslPem.PublicKeyPemBytesFromKeyOrCert(AKey, FCertificate);
+    BIO_write(LKeyBuffer, @LPem[0], Length(LPem));
 
     Result := JoseSSL.PEM_read_bio_PUBKEY(LKeyBuffer, nil, nil, nil);
     if Result = nil then
@@ -772,12 +758,14 @@ function TDefaultECDSAProvider.VerifyPublicKey(const AKey: TBytes): Boolean;
 var
   LBio: PBIO;
   LKey: PEVP_PKEY;
+  LPem: TBytes;
 begin
   TJOSEDefaultOpenSslPem.LoadOpenSSL;
 
   LBio := BIO_new(BIO_s_mem);
   try
-    BIO_write(LBio, @AKey[0], Length(AKey));
+    LPem := TJOSEDefaultOpenSslPem.PublicKeyPemBytesFromKeyOrCert(AKey, FCertificate);
+    BIO_write(LBio, @LPem[0], Length(LPem));
     LKey := JoseSSL.PEM_read_bio_PUBKEY(LBio, nil, nil, nil);
 
     Result := (LKey <> nil);
@@ -792,7 +780,7 @@ function TDefaultECDSAProvider.VerifyWithCertificate(const AInput, ASignature, A
 var
   LKey: PEVP_PKEY;
 begin
-  LKey := LoadPublicKeyFromCert(ACertificate, TJOSECertificatePublicKey.EC);
+  LKey := TJOSEDefaultOpenSslPem.LoadPublicKeyFromCert(ACertificate, TJOSECertificatePublicKey.EC);
   try
     Result := InternalVerify(AInput, ASignature, LKey, AAlg);
   finally
@@ -1040,5 +1028,34 @@ begin
   end;
 end;
 {$IFEND}
+
+{ TJOSEDefaultProviders }
+
+class procedure TJOSEDefaultProviders.Register;
+{$IFDEF RSA_SIGNING}
+var
+  LCert: IJOSECertificateProvider;
+{$ENDIF}
+begin
+  TJOSEProviders.Base64 := TDefaultBase64Provider.Create;
+  TJOSEProviders.HMAC := TDefaultHmacProvider.Create;
+{$IFDEF RSA_SIGNING}
+  LCert := TDefaultCertificateProvider.Create;
+  TJOSEProviders.Certificate := LCert;
+  TJOSEProviders.RSA := TDefaultRSAProvider.Create(LCert);
+  TJOSEProviders.ECDSA := TDefaultECDSAProvider.Create(LCert);
+{$ENDIF}
+end;
+
+class procedure TJOSEDefaultProviders.Unregister;
+begin
+  TJOSEProviders.Base64 := nil;
+  TJOSEProviders.HMAC := nil;
+{$IFDEF RSA_SIGNING}
+  TJOSEProviders.Certificate := nil;
+  TJOSEProviders.RSA := nil;
+  TJOSEProviders.ECDSA := nil;
+{$ENDIF}
+end;
 
 end.

--- a/Source/Common/JOSE.Providers.Interfaces.pas
+++ b/Source/Common/JOSE.Providers.Interfaces.pas
@@ -1,0 +1,80 @@
+{******************************************************************************}
+{                                                                              }
+{  Delphi JOSE Library                                                         }
+{  Copyright (c) 2015 Paolo Rossi                                              }
+{  https://github.com/paolo-rossi/delphi-jose-jwt                              }
+{                                                                              }
+{******************************************************************************}
+{                                                                              }
+{  Licensed under the Apache License, Version 2.0 (the "License");             }
+{  you may not use this file except in compliance with the License.            }
+{  You may obtain a copy of the License at                                     }
+{                                                                              }
+{      http://www.apache.org/licenses/LICENSE-2.0                              }
+{                                                                              }
+{  Unless required by applicable law or agreed to in writing, software         }
+{  distributed under the License is distributed on an "AS IS" BASIS,           }
+{  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    }
+{  See the License for the specific language governing permissions and         }
+{  limitations under the License.                                              }
+{                                                                              }
+{******************************************************************************}
+
+unit JOSE.Providers.Interfaces;
+
+{$I ..\JOSE.inc}
+
+interface
+
+uses
+  System.SysUtils,
+  JOSE.Types.Bytes,
+  JOSE.Crypto.Algorithms;
+
+type
+  IJOSEBase64Provider = interface
+    ['{8F2E9C1D-4A3B-4E5F-9D8C-7B6A50413210}']
+    function Encode(const ASource: TJOSEBytes): TJOSEBytes;
+    function Decode(const ASource: TJOSEBytes): TJOSEBytes;
+    function TryDecode(const ASource: TJOSEBytes): TJOSEBytes;
+    function URLEncode(const ASource: TJOSEBytes): TJOSEBytes;
+    function URLDecode(const ASource: TJOSEBytes): TJOSEBytes;
+    function TryURLDecode(const ASource: TJOSEBytes): TJOSEBytes;
+  end;
+
+  IJOSEHmacProvider = interface
+    ['{7D1C8B2E-5F4A-4D3C-8E9F-1029384756AB}']
+    function Sign(const AInput, AKey: TBytes; AAlg: THMACAlgorithm): TBytes;
+  end;
+
+{$IFDEF RSA_SIGNING}
+
+  IJOSECertificateProvider = interface
+    ['{6E0B7A3D-2C1F-4E5D-9A8B-7C6D5E4F3021}']
+    function PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
+    function VerifyCertificate(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): Boolean;
+  end;
+
+  IJOSESignerRSA = interface
+    ['{5D9C8B1E-3A2F-4D5C-8B7A-6C5D4E3F2010}']
+    function Sign(const AInput, AKey: TBytes; AAlg: TRSAAlgorithm): TBytes;
+    function Verify(const AInput, ASignature, AKey: TBytes; AAlg: TRSAAlgorithm): Boolean;
+    function VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TRSAAlgorithm): Boolean;
+    function VerifyPublicKey(const AKey: TBytes): Boolean;
+    function VerifyPrivateKey(const AKey: TBytes): Boolean;
+  end;
+
+  IJOSESignerECDSA = interface
+    ['{4C8B7A2D-1E0F-4C3B-7A6C-5B4D3E2F1098}']
+    function Sign(const AInput, APrivateKey: TBytes; AAlg: TECDSAAlgorithm): TBytes;
+    function Verify(const AInput, ASignature, APublicKey: TBytes; AAlg: TECDSAAlgorithm): Boolean;
+    function VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TECDSAAlgorithm): Boolean;
+    function VerifyPublicKey(const AKey: TBytes): Boolean;
+    function VerifyPrivateKey(const AKey: TBytes): Boolean;
+  end;
+
+{$ENDIF}
+
+implementation
+
+end.

--- a/Source/Common/JOSE.Providers.pas
+++ b/Source/Common/JOSE.Providers.pas
@@ -45,26 +45,24 @@ type
     class procedure EnsureDefaults; static;
     class function GetBase64: IJOSEBase64Provider; static;
     class function GetHMAC: IJOSEHmacProvider; static;
+    class procedure SetBase64(const AValue: IJOSEBase64Provider); static;
+    class procedure SetHMAC(const AValue: IJOSEHmacProvider); static;
 {$IFDEF RSA_SIGNING}
     class procedure EnsureSigningStack; static;
     class function GetCertificate: IJOSECertificateProvider; static;
     class function GetRSA: IJOSESignerRSA; static;
     class function GetECDSA: IJOSESignerECDSA; static;
+    class procedure SetCertificate(const AValue: IJOSECertificateProvider); static;
+    class procedure SetRSA(const AValue: IJOSESignerRSA); static;
+    class procedure SetECDSA(const AValue: IJOSESignerECDSA); static;
 {$ENDIF}
   public
-    class property Base64: IJOSEBase64Provider read GetBase64;
-    class property HMAC: IJOSEHmacProvider read GetHMAC;
+    class property Base64: IJOSEBase64Provider read GetBase64 write SetBase64;
+    class property HMAC: IJOSEHmacProvider read GetHMAC write SetHMAC;
 {$IFDEF RSA_SIGNING}
-    class property Certificate: IJOSECertificateProvider read GetCertificate;
-    class property RSA: IJOSESignerRSA read GetRSA;
-    class property ECDSA: IJOSESignerECDSA read GetECDSA;
-{$ENDIF}
-    class procedure SetBase64(const AProvider: IJOSEBase64Provider); static;
-    class procedure SetHMAC(const AProvider: IJOSEHmacProvider); static;
-{$IFDEF RSA_SIGNING}
-    class procedure SetCertificate(const AProvider: IJOSECertificateProvider); static;
-    class procedure SetRSA(const AProvider: IJOSESignerRSA); static;
-    class procedure SetECDSA(const AProvider: IJOSESignerECDSA); static;
+    class property Certificate: IJOSECertificateProvider read GetCertificate write SetCertificate;
+    class property RSA: IJOSESignerRSA read GetRSA write SetRSA;
+    class property ECDSA: IJOSESignerECDSA read GetECDSA write SetECDSA;
 {$ENDIF}
   end;
 
@@ -93,6 +91,16 @@ class function TJOSEProviders.GetHMAC: IJOSEHmacProvider;
 begin
   EnsureDefaults;
   Result := FHMAC;
+end;
+
+class procedure TJOSEProviders.SetBase64(const AValue: IJOSEBase64Provider);
+begin
+  FBase64 := AValue;
+end;
+
+class procedure TJOSEProviders.SetHMAC(const AValue: IJOSEHmacProvider);
+begin
+  FHMAC := AValue;
 end;
 
 {$IFDEF RSA_SIGNING}
@@ -126,34 +134,20 @@ begin
   Result := FECDSA;
 end;
 
-{$ENDIF}
-
-class procedure TJOSEProviders.SetBase64(const AProvider: IJOSEBase64Provider);
+class procedure TJOSEProviders.SetCertificate(const AValue: IJOSECertificateProvider);
 begin
-  FBase64 := AProvider;
-end;
-
-class procedure TJOSEProviders.SetHMAC(const AProvider: IJOSEHmacProvider);
-begin
-  FHMAC := AProvider;
-end;
-
-{$IFDEF RSA_SIGNING}
-
-class procedure TJOSEProviders.SetCertificate(const AProvider: IJOSECertificateProvider);
-begin
-  FCertificate := AProvider;
+  FCertificate := AValue;
   FRSA := nil;
 end;
 
-class procedure TJOSEProviders.SetRSA(const AProvider: IJOSESignerRSA);
+class procedure TJOSEProviders.SetRSA(const AValue: IJOSESignerRSA);
 begin
-  FRSA := AProvider;
+  FRSA := AValue;
 end;
 
-class procedure TJOSEProviders.SetECDSA(const AProvider: IJOSESignerECDSA);
+class procedure TJOSEProviders.SetECDSA(const AValue: IJOSESignerECDSA);
 begin
-  FECDSA := AProvider;
+  FECDSA := AValue;
 end;
 
 {$ENDIF}

--- a/Source/Common/JOSE.Providers.pas
+++ b/Source/Common/JOSE.Providers.pas
@@ -1,0 +1,161 @@
+{******************************************************************************}
+{                                                                              }
+{  Delphi JOSE Library                                                         }
+{  Copyright (c) 2015 Paolo Rossi                                              }
+{  https://github.com/paolo-rossi/delphi-jose-jwt                              }
+{                                                                              }
+{******************************************************************************}
+{                                                                              }
+{  Licensed under the Apache License, Version 2.0 (the "License");             }
+{  you may not use this file except in compliance with the License.            }
+{  You may obtain a copy of the License at                                     }
+{                                                                              }
+{      http://www.apache.org/licenses/LICENSE-2.0                              }
+{                                                                              }
+{  Unless required by applicable law or agreed to in writing, software         }
+{  distributed under the License is distributed on an "AS IS" BASIS,           }
+{  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    }
+{  See the License for the specific language governing permissions and         }
+{  limitations under the License.                                              }
+{                                                                              }
+{******************************************************************************}
+
+unit JOSE.Providers;
+
+{$I ..\JOSE.inc}
+
+interface
+
+uses
+  JOSE.Providers.Interfaces;
+
+type
+  /// <summary>
+  ///   Global crypto/encoding providers.
+  /// </summary>
+  TJOSEProviders = class
+  private
+    class var FBase64: IJOSEBase64Provider;
+    class var FHMAC: IJOSEHmacProvider;
+{$IFDEF RSA_SIGNING}
+    class var FCertificate: IJOSECertificateProvider;
+    class var FRSA: IJOSESignerRSA;
+    class var FECDSA: IJOSESignerECDSA;
+{$ENDIF}
+    class procedure EnsureDefaults; static;
+    class function GetBase64: IJOSEBase64Provider; static;
+    class function GetHMAC: IJOSEHmacProvider; static;
+{$IFDEF RSA_SIGNING}
+    class procedure EnsureSigningStack; static;
+    class function GetCertificate: IJOSECertificateProvider; static;
+    class function GetRSA: IJOSESignerRSA; static;
+    class function GetECDSA: IJOSESignerECDSA; static;
+{$ENDIF}
+  public
+    class property Base64: IJOSEBase64Provider read GetBase64;
+    class property HMAC: IJOSEHmacProvider read GetHMAC;
+{$IFDEF RSA_SIGNING}
+    class property Certificate: IJOSECertificateProvider read GetCertificate;
+    class property RSA: IJOSESignerRSA read GetRSA;
+    class property ECDSA: IJOSESignerECDSA read GetECDSA;
+{$ENDIF}
+    class procedure SetBase64(const AProvider: IJOSEBase64Provider); static;
+    class procedure SetHMAC(const AProvider: IJOSEHmacProvider); static;
+{$IFDEF RSA_SIGNING}
+    class procedure SetCertificate(const AProvider: IJOSECertificateProvider); static;
+    class procedure SetRSA(const AProvider: IJOSESignerRSA); static;
+    class procedure SetECDSA(const AProvider: IJOSESignerECDSA); static;
+{$ENDIF}
+  end;
+
+implementation
+
+uses
+  JOSE.Providers.Default;
+
+{ TJOSEProviders }
+
+class procedure TJOSEProviders.EnsureDefaults;
+begin
+  if FBase64 = nil then
+    FBase64 := TDefaultBase64Provider.Create;
+  if FHMAC = nil then
+    FHMAC := TDefaultHmacProvider.Create;
+end;
+
+class function TJOSEProviders.GetBase64: IJOSEBase64Provider;
+begin
+  EnsureDefaults;
+  Result := FBase64;
+end;
+
+class function TJOSEProviders.GetHMAC: IJOSEHmacProvider;
+begin
+  EnsureDefaults;
+  Result := FHMAC;
+end;
+
+{$IFDEF RSA_SIGNING}
+
+class procedure TJOSEProviders.EnsureSigningStack;
+begin
+  EnsureDefaults;
+  if FCertificate = nil then
+    FCertificate := TDefaultCertificateProvider.Create;
+  if FRSA = nil then
+    FRSA := TDefaultRSAProvider.Create(FCertificate);
+  if FECDSA = nil then
+    FECDSA := TDefaultECDSAProvider.Create;
+end;
+
+class function TJOSEProviders.GetCertificate: IJOSECertificateProvider;
+begin
+  EnsureSigningStack;
+  Result := FCertificate;
+end;
+
+class function TJOSEProviders.GetRSA: IJOSESignerRSA;
+begin
+  EnsureSigningStack;
+  Result := FRSA;
+end;
+
+class function TJOSEProviders.GetECDSA: IJOSESignerECDSA;
+begin
+  EnsureSigningStack;
+  Result := FECDSA;
+end;
+
+{$ENDIF}
+
+class procedure TJOSEProviders.SetBase64(const AProvider: IJOSEBase64Provider);
+begin
+  FBase64 := AProvider;
+end;
+
+class procedure TJOSEProviders.SetHMAC(const AProvider: IJOSEHmacProvider);
+begin
+  FHMAC := AProvider;
+end;
+
+{$IFDEF RSA_SIGNING}
+
+class procedure TJOSEProviders.SetCertificate(const AProvider: IJOSECertificateProvider);
+begin
+  FCertificate := AProvider;
+  FRSA := nil;
+end;
+
+class procedure TJOSEProviders.SetRSA(const AProvider: IJOSESignerRSA);
+begin
+  FRSA := AProvider;
+end;
+
+class procedure TJOSEProviders.SetECDSA(const AProvider: IJOSESignerECDSA);
+begin
+  FECDSA := AProvider;
+end;
+
+{$ENDIF}
+
+end.

--- a/Source/Common/JOSE.Providers.pas
+++ b/Source/Common/JOSE.Providers.pas
@@ -27,11 +27,16 @@ unit JOSE.Providers;
 interface
 
 uses
+  System.SysUtils,
   JOSE.Providers.Interfaces;
 
 type
+  /// <summary>Raised when a global provider slot is nil (e.g. after <c>Unregister</c>).</summary>
+  EJOSEProvidersNotRegistered = class(Exception);
+
   /// <summary>
-  ///   Global crypto/encoding providers.
+  ///   Global crypto/encoding providers. Default stack is registered from <c>initialization</c>;
+  ///   call <c>TJOSEProviders.RegisterDefault</c> again if you use <c>UnregisterDefault</c>.
   /// </summary>
   TJOSEProviders = class
   private
@@ -42,13 +47,16 @@ type
     class var FRSA: IJOSESignerRSA;
     class var FECDSA: IJOSESignerECDSA;
 {$ENDIF}
-    class procedure EnsureDefaults; static;
+    class procedure RequireBase64; static;
+    class procedure RequireHMAC; static;
+{$IFDEF RSA_SIGNING}
+    class procedure RequireSigningStack; static;
+{$ENDIF}
     class function GetBase64: IJOSEBase64Provider; static;
     class function GetHMAC: IJOSEHmacProvider; static;
     class procedure SetBase64(const AValue: IJOSEBase64Provider); static;
     class procedure SetHMAC(const AValue: IJOSEHmacProvider); static;
 {$IFDEF RSA_SIGNING}
-    class procedure EnsureSigningStack; static;
     class function GetCertificate: IJOSECertificateProvider; static;
     class function GetRSA: IJOSESignerRSA; static;
     class function GetECDSA: IJOSESignerECDSA; static;
@@ -57,6 +65,10 @@ type
     class procedure SetECDSA(const AValue: IJOSESignerECDSA); static;
 {$ENDIF}
   public
+    /// <summary>Delegates to <c>TJOSEDefaultProviders.Register</c>.</summary>
+    class procedure RegisterProvider; static;
+    /// <summary>Delegates to <c>TJOSEDefaultProviders.Unregister</c>.</summary>
+    class procedure UnregisterProvider; static;
     class property Base64: IJOSEBase64Provider read GetBase64 write SetBase64;
     class property HMAC: IJOSEHmacProvider read GetHMAC write SetHMAC;
 {$IFDEF RSA_SIGNING}
@@ -71,25 +83,33 @@ implementation
 uses
   JOSE.Providers.Default;
 
+resourcestring
+  SJOSEProvidersNotRegistered = 'JOSE global providers are not registered. Call TJOSEProviders.RegisterDefault or ' +
+    'TJOSECryptoLibProviders.Register.';
+
 { TJOSEProviders }
 
-class procedure TJOSEProviders.EnsureDefaults;
+class procedure TJOSEProviders.RequireBase64;
 begin
   if FBase64 = nil then
-    FBase64 := TDefaultBase64Provider.Create;
+    raise EJOSEProvidersNotRegistered.Create(SJOSEProvidersNotRegistered);
+end;
+
+class procedure TJOSEProviders.RequireHMAC;
+begin
   if FHMAC = nil then
-    FHMAC := TDefaultHmacProvider.Create;
+    raise EJOSEProvidersNotRegistered.Create(SJOSEProvidersNotRegistered);
 end;
 
 class function TJOSEProviders.GetBase64: IJOSEBase64Provider;
 begin
-  EnsureDefaults;
+  RequireBase64;
   Result := FBase64;
 end;
 
 class function TJOSEProviders.GetHMAC: IJOSEHmacProvider;
 begin
-  EnsureDefaults;
+  RequireHMAC;
   Result := FHMAC;
 end;
 
@@ -103,34 +123,43 @@ begin
   FHMAC := AValue;
 end;
 
+class procedure TJOSEProviders.RegisterProvider;
+begin
+  TJOSEDefaultProviders.Register;
+end;
+
+class procedure TJOSEProviders.UnregisterProvider;
+begin
+  TJOSEDefaultProviders.Unregister;
+end;
+
 {$IFDEF RSA_SIGNING}
 
-class procedure TJOSEProviders.EnsureSigningStack;
+class procedure TJOSEProviders.RequireSigningStack;
 begin
-  EnsureDefaults;
   if FCertificate = nil then
-    FCertificate := TDefaultCertificateProvider.Create;
+    raise EJOSEProvidersNotRegistered.Create(SJOSEProvidersNotRegistered);
   if FRSA = nil then
-    FRSA := TDefaultRSAProvider.Create(FCertificate);
+    raise EJOSEProvidersNotRegistered.Create(SJOSEProvidersNotRegistered);
   if FECDSA = nil then
-    FECDSA := TDefaultECDSAProvider.Create;
+    raise EJOSEProvidersNotRegistered.Create(SJOSEProvidersNotRegistered);
 end;
 
 class function TJOSEProviders.GetCertificate: IJOSECertificateProvider;
 begin
-  EnsureSigningStack;
+  RequireSigningStack;
   Result := FCertificate;
 end;
 
 class function TJOSEProviders.GetRSA: IJOSESignerRSA;
 begin
-  EnsureSigningStack;
+  RequireSigningStack;
   Result := FRSA;
 end;
 
 class function TJOSEProviders.GetECDSA: IJOSESignerECDSA;
 begin
-  EnsureSigningStack;
+  RequireSigningStack;
   Result := FECDSA;
 end;
 
@@ -151,5 +180,8 @@ begin
 end;
 
 {$ENDIF}
+
+initialization
+  TJOSEProviders.RegisterProvider;
 
 end.

--- a/Source/Common/JOSE.Signing.Base.pas
+++ b/Source/Common/JOSE.Signing.Base.pas
@@ -30,40 +30,15 @@ interface
 
 uses
   System.SysUtils,
-  System.StrUtils,
-  IdGlobal, IdCTypes,
-  IdSSLOpenSSLHeaders,
-  JOSE.OpenSSL.Headers,
-  JOSE.Encoding.Base64;
+  JOSE.Crypto.Algorithms;
 
 type
   ESignException = class(Exception);
 
   TSigningBase = class
-  strict private class var
-    FPEM_X509_CERTIFICATE: TBytes;
-    FPEM_PUBKEY_PKCS1: TBytes;
-    FPEM_PUBKEY: TBytes;
-    FPEM_PRVKEY_PKCS8: TBytes;
-    FPEM_PRVKEY_PKCS1: TBytes;
-    class constructor Create;
-  protected //CERT
-    class property PEM_X509_CERTIFICATE: TBytes read FPEM_X509_CERTIFICATE;
-  protected //RSA
-    class property PEM_PUBKEY_PKCS1: TBytes read FPEM_PUBKEY_PKCS1;
-  protected  //ECDSA
-    class property PEM_PUBKEY: TBytes read FPEM_PUBKEY;
-    class property PEM_PRVKEY_PKCS8: TBytes read FPEM_PRVKEY_PKCS8;
-    class property PEM_PRVKEY_PKCS1: TBytes read FPEM_PRVKEY_PKCS1;
-
-    class function LoadCertificate(const ACertificate: TBytes): PX509;
-    class function LoadPublicKeyFromCert(const ACertificate: TBytes): PEVP_PKEY; overload;
-    class function LoadPublicKeyFromCert(const ACertificate: TBytes; AAlgID: Integer): PEVP_PKEY; overload;
   public
-    class procedure LoadOpenSSL;
-
     class function PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
-    class function VerifyCertificate(const ACertificate: TBytes; AObjectID: Integer): Boolean;
+    class function VerifyCertificate(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): Boolean;
   end;
 
 {$ENDIF}
@@ -73,134 +48,16 @@ implementation
 {$IFDEF RSA_SIGNING}
 
 uses
-  JOSE.Types.Utils;
-
-class constructor TSigningBase.Create;
-begin
-  FPEM_X509_CERTIFICATE := TEncoding.ASCII.GetBytes('-----BEGIN CERTIFICATE-----');
-  FPEM_PUBKEY_PKCS1 := TEncoding.ASCII.GetBytes('-----BEGIN RSA PUBLIC KEY-----');
-  FPEM_PUBKEY := TEncoding.ASCII.GetBytes('-----BEGIN PUBLIC KEY-----');
-  FPEM_PRVKEY_PKCS8 := TEncoding.ASCII.GetBytes('-----BEGIN PRIVATE KEY-----');
-  FPEM_PRVKEY_PKCS1 := TEncoding.ASCII.GetBytes('-----BEGIN EC PRIVATE KEY-----');
-end;
-
-class function TSigningBase.LoadCertificate(const ACertificate: TBytes): PX509;
-var
-  LBio: PBIO;
-begin
-  if not CompareMem(@PEM_X509_CERTIFICATE[0], @ACertificate[0], Length(PEM_X509_CERTIFICATE)) then
-    raise ESignException.Create('[OpenSSL] Not a valid X509 certificate');
-
-  LBio := BIO_new(BIO_s_mem);
-  try
-    BIO_write(LBio, @ACertificate[0], Length(ACertificate));
-    Result := PEM_read_bio_X509(LBio, nil, nil, nil);
-    if Result = nil then
-      raise ESignException.Create('[OpenSSL] Error loading X509 certificate');
-  finally
-    BIO_free(LBio);
-  end;
-end;
-
-class procedure TSigningBase.LoadOpenSSL;
-begin
-  if not IdSSLOpenSSLHeaders.Load then
-    raise ESignException.Create('[OpenSSL] Unable to load OpenSSL libraries');
-
-  if not JoseSSL.Load then
-    raise ESignException.Create('[OpenSSL] Unable to load OpenSSL libraries');
-
-  if @EVP_DigestVerifyInit = nil then
-    raise ESignException.Create('[OpenSSL] Please, use OpenSSL 1.0.0 or newer!');
-end;
-
-class function TSigningBase.LoadPublicKeyFromCert(const ACertificate: TBytes; AAlgID: Integer): PEVP_PKEY;
-var
-  LCer: PX509;
-  LAlg: Integer;
-begin
-{$IF CompilerVersion < 33 } // Delphi 10.3 Rio or lower
-   Result := nil; // prevent compiler warning
-{$IFEND}
-   LoadOpenSSL;
-
-  LCer := LoadCertificate(ACertificate);
-  try
-    LAlg := OBJ_obj2nid(LCer.cert_info.key.algor.algorithm);
-    if LAlg <> AAlgID then
-      raise ESignException.Create('[OpenSSL] Unsupported algorithm type in X509 public key (RSA expected)');
-
-    Result := X509_PUBKEY_get(LCer.cert_info.key);
-    if not Assigned(Result) then
-      raise ESignException.Create('[OpenSSL] Error extracting public key from X509 certificate');
-  finally
-    X509_free(LCer);
-  end;
-end;
-
-class function TSigningBase.LoadPublicKeyFromCert(const ACertificate: TBytes): PEVP_PKEY;
-var
-  LCer: PX509;
-begin
-  LoadOpenSSL;
-
-  LCer := LoadCertificate(ACertificate);
-  try
-    Result := X509_PUBKEY_get(LCer.cert_info.key);
-    if not Assigned(Result) then
-      raise ESignException.Create('[OpenSSL] Error extracting public key from X509 certificate');
-  finally
-    X509_free(LCer);
-  end;
-end;
+  JOSE.Providers;
 
 class function TSigningBase.PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
-var
-  LKey: PEVP_PKEY;
-  LBio: PBIO;
-  LBuffer: TBytes;
-  LBytesRead: Integer;
 begin
-  LKey := LoadPublicKeyFromCert(ACertificate);
-  try
-    LBio := BIO_new(BIO_s_mem);
-    try
-      JoseSSL.PEM_write_bio_PUBKEY(LBio, LKey);
-
-      Result := [];
-      SetLength(LBuffer, 255);
-      repeat
-        LBytesRead := BIO_read(LBio, @LBuffer[0], 255);
-        TJOSEUtils.ArrayPush(LBuffer, Result, LBytesRead);
-      until (LBytesRead <= 0);
-    finally
-      BIO_free(LBio);
-    end;
-  finally
-    EVP_PKEY_free(LKey);
-  end;
+  Result := TJOSEProviders.Certificate.PublicKeyFromCertificate(ACertificate);
 end;
 
-class function TSigningBase.VerifyCertificate(const ACertificate: TBytes; AObjectID: Integer): Boolean;
-var
-  LCer: PX509;
-  LKey: PEVP_PKEY;
-  LAlg: Integer;
+class function TSigningBase.VerifyCertificate(const ACertificate: TBytes; AExpected: TJOSECertificatePublicKey): Boolean;
 begin
-  LoadOpenSSL;
-
-  LCer := LoadCertificate(ACertificate);
-  try
-    LKey := X509_PUBKEY_get(LCer.cert_info.key);
-    try
-      LAlg := OBJ_obj2nid(LCer.cert_info.key.algor.algorithm);
-      Result := Assigned(LCer) and Assigned(LKey) and (LAlg = AObjectID);
-    finally
-      EVP_PKEY_free(LKey);
-    end;
-  finally
-    X509_free(LCer);
-  end;
+  Result := TJOSEProviders.Certificate.VerifyCertificate(ACertificate, AExpected);
 end;
 
 {$ENDIF}

--- a/Source/Common/JOSE.Signing.ECDSA.pas
+++ b/Source/Common/JOSE.Signing.ECDSA.pas
@@ -30,32 +30,14 @@ interface
 
 uses
   System.SysUtils,
-  System.StrUtils,
-  IdGlobal, IdCTypes,
-  IdSSLOpenSSLHeaders,
-  JOSE.OpenSSL.Headers,
-  JOSE.Types.Utils,
-  JOSE.Signing.Base,
-  JOSE.Encoding.Base64;
+  JOSE.Crypto.Algorithms,
+  JOSE.Signing.Base;
 
 type
-  TECDSAAlgorithm = (ES256, ES256K, ES384, ES512);
-  TECDSAAlgorithmHelper = record helper for TECDSAAlgorithm
-    procedure FromString(const AValue: string);
-    function ToString: string;
-  end;
+  TECDSAAlgorithm = JOSE.Crypto.Algorithms.TECDSAAlgorithm;
+  TECDSAAlgorithmHelper = JOSE.Crypto.Algorithms.TECDSAAlgorithmHelper;
 
   TECDSA = class(TSigningBase)
-  private
-    class function LoadPublicKey(const AKey: TBytes): PEVP_PKEY;
-    class function LoadPrivateKey(const AKey: TBytes): PEVP_PKEY;
-
-    class function InternalSign(const AInput: TBytes; AKey: PEVP_PKEY; AAlg: TECDSAAlgorithm): TBytes;
-    class function InternalVerify(const AInput, ASignature: TBytes; APublicKey: PEVP_PKEY; AAlg: TECDSAAlgorithm): Boolean;
-
-    class function HashFromBytes(const AInput: TBytes; AAlg: TECDSAAlgorithm): TBytes;
-    class function Sig2OctetSequence(ASignature: PECDSA_SIG; AAlg: TECDSAAlgorithm): TBytes;
-    class function OctetSequence2Sig(const ASignature: TBytes; AAlg: TECDSAAlgorithm): PECDSA_SIG;
   public
     class function Sign(const AInput, APrivateKey: TBytes; AAlg: TECDSAAlgorithm): TBytes;
     class function Verify(const AInput, ASignature, APublicKey: TBytes; AAlg: TECDSAAlgorithm): Boolean;
@@ -71,276 +53,34 @@ implementation
 
 {$IFDEF RSA_SIGNING}
 
-{ TECDSAAlgorithmHelper }
-
-procedure TECDSAAlgorithmHelper.FromString(const AValue: string);
-begin
-  if AValue = 'ES256' then
-    Self := ES256
-  else if AValue = 'ES256K' then
-    Self := ES256K
-  else if AValue = 'ES384' then
-    Self := ES384
-  else if AValue = 'ES512' then
-    Self := ES512
-  else
-    raise ESignException.Create('Invalid ECDSA algorithm type');
-end;
-
-function TECDSAAlgorithmHelper.ToString: string;
-begin
-  case Self of
-    ES256: Result := 'ES256';
-    ES256K: Result := 'ES256K';
-    ES384: Result := 'ES384';
-    ES512: Result := 'ES512';
-  end;
-end;
-
-class function TECDSA.HashFromBytes(const AInput: TBytes; AAlg: TECDSAAlgorithm): TBytes;
-var
-  LShaLen: Integer;
-begin
-  case AAlg of
-    ES256, ES256K:
-    begin
-      LShaLen := SHA256_DIGEST_LENGTH;
-      SetLength(Result, LShaLen);
-      JoseSSL.SHA256(@AInput[0], Length(AInput), @Result[0]);
-    end;
-    ES384:
-    begin
-      LShaLen := SHA384_DIGEST_LENGTH;
-      SetLength(Result, LShaLen);
-      JoseSSL.SHA384(@AInput[0], Length(AInput), @Result[0]);
-    end;
-    ES512:
-    begin
-      LShaLen := SHA512_DIGEST_LENGTH;
-      SetLength(Result, LShaLen);
-      JoseSSL.SHA512(@AInput[0], Length(AInput), @Result[0]);
-    end
-  else
-    raise Exception.Create('[ECDSA] Unsupported signing algorithm!');
-  end;
-end;
+uses
+  JOSE.Providers;
 
 { TECDSA }
 
-class function TECDSA.InternalVerify(const AInput, ASignature: TBytes; APublicKey:
-    PEVP_PKEY; AAlg: TECDSAAlgorithm): Boolean;
-var
-  LECKey: PEC_KEY;
-  LSig: PECDSA_SIG;
-  LShaHash: TBytes;
-begin
-  LoadOpenSSL;
-
-  // Get the actual ec_key
-  LECKey := EVP_PKEY_get1_EC_KEY(APublicKey);
-  if LECKey = nil then
-    raise Exception.Create('[ECDSA] Error getting memory for ECDSA');
-  try
-    // Pick R & S from the octect representation
-    LSig := OctetSequence2Sig(ASignature, AAlg);
-    try
-      // Calculate SHA Hash value from input
-      LShaHash := HashFromBytes(AInput, AAlg);
-      Result := JoseSSL.ECDSA_do_verify(@LShaHash[0], Length(LShaHash), LSig, LECKey) = 1;
-    finally
-      JoseSSL.ECDSA_SIG_free(LSig);
-    end;
-  finally
-    JoseSSL.EC_KEY_free(LECKey);
-  end;
-end;
-
-class function TECDSA.LoadPrivateKey(const AKey: TBytes): PEVP_PKEY;
-var
-  LBIO: PBIO;
-begin
-  LoadOpenSSL;
-
-  // Load Private Key into ECDSA object
-  LBIO := BIO_new(BIO_s_mem);
-  try
-    BIO_write(LBIO, @AKey[0], Length(AKey));
-    Result := PEM_read_bio_PrivateKey(LBIO, nil, nil, nil);
-    if Result = nil then
-      raise ESignException.Create('[ECDSA] Unable to load private key: ' + JOSESSL.GetLastError);
-    //LKeyType := EVP_PKEY_id(LKey);
-  finally
-    BIO_free(LBIO);
-  end;
-end;
-
-class function TECDSA.LoadPublicKey(const AKey: TBytes): PEVP_PKEY;
-var
-  LKeyBuffer: PBIO;
-begin
-  LoadOpenSSL;
-
-  // Load Public ECDSA Key into ECDSA object
-  LKeyBuffer := BIO_new(BIO_s_mem);
-  try
-    // Check Key prologue
-    BIO_write(LKeyBuffer, @AKey[0], Length(AKey));
-
-    Result := JoseSSL.PEM_read_bio_PUBKEY(LKeyBuffer, nil, nil, nil);
-    if Result = nil then
-      raise Exception.Create('[ECDSA] Unable to load public key: ' + JOSESSL.GetLastError);
-  finally
-    BIO_free(LKeyBuffer);
-  end;
-end;
-
 class function TECDSA.Sign(const AInput, APrivateKey: TBytes; AAlg: TECDSAAlgorithm): TBytes;
-var
-  LKey: PEVP_PKEY;
 begin
-  LoadOpenSSL;
-  Result := [];
-
-  LKey := LoadPrivateKey(APrivateKey);
-  try
-    Result := InternalSign(AInput, LKey, AAlg);
-  finally
-    EVP_PKEY_free(LKey);
-  end;
-end;
-
-class function TECDSA.InternalSign(const AInput: TBytes; AKey: PEVP_PKEY; AAlg: TECDSAAlgorithm): TBytes;
-var
-  LECKey: PEC_KEY;
-  LSig: PECDSA_SIG;
-  LShaHash: TBytes;
-begin
-  LoadOpenSSL;
-
-  Result := [];
-  // Convert to a RAW format for the R/S
-  LECKey := EVP_PKEY_get1_EC_KEY(AKey);
-  if LECKey = nil then
-    raise ESignException.Create('[ECDSA] Error getting EC Key: ' + JOSESSL.GetLastError);
-  try
-    // Calculate SHA Hash value from Input
-    LShaHash := HashFromBytes(AInput, AAlg);
-
-    LSig := JoseSSL.ECDSA_do_sign(@LShaHash[0], Length(LShaHash), LECKey);
-    if LSig = nil then
-      raise ESignException.Create('[ECDSA] Digest signing failed: ' + JOSESSL.GetLastError);
-    try
-      // Convert R & S to octect repr. and write them
-      Result := Sig2OctetSequence(LSig, AAlg);
-    finally
-      JoseSSL.ECDSA_SIG_free(LSig);
-    end;
-  finally
-    JoseSSL.EC_KEY_free(LECKey);
-  end;
-end;
-
-class function TECDSA.OctetSequence2Sig(const ASignature: TBytes; AAlg: TECDSAAlgorithm): PECDSA_SIG;
-var
-  LKeyLength: Integer;
-begin
-  Result := JoseSSL.ECDSA_SIG_new();
-  LKeyLength := Length(ASignature) div 2;
-
-  JoseSSL.BN_bin2bn(Pointer(ASignature), LKeyLength, Result.r);
-  JoseSSL.BN_bin2bn(Pointer(NativeInt(ASignature) + LKeyLength), LKeyLength, Result.s);
-end;
-
-class function TECDSA.Sig2OctetSequence(ASignature: PECDSA_SIG; AAlg: TECDSAAlgorithm): TBytes;
-var
-  LSigLength, LRLength, LSLength: Integer;
-begin
-  LSigLength := 0;
-
-  case AAlg of
-    ES256:  LSigLength := 32 * 2;
-    ES256K: LSigLength := 32 * 2;
-    ES384:  LSigLength := 48 * 2;
-    ES512:  LSigLength := 66 * 2;
-  end;
-
-  LRLength := JoseSSL.BN_num_bytes(ASignature.r);
-  LSLength := JoseSSL.BN_num_bytes(ASignature.s);
-
-  SetLength(Result, LSigLength);
-  FillChar(Result[0], LSigLength, #0);
-
-  JoseSSL.BN_bn2bin(ASignature.r, Pointer(NativeInt(Result) + (LSigLength div 2) - LRLength));
-  JoseSSL.BN_bn2bin(ASignature.s, Pointer(NativeInt(Result) + LSigLength - LSLength));
+  Result := TJOSEProviders.ECDSA.Sign(AInput, APrivateKey, AAlg);
 end;
 
 class function TECDSA.Verify(const AInput, ASignature, APublicKey: TBytes; AAlg: TECDSAAlgorithm): Boolean;
-var
-  LPubKey: PEVP_PKEY;
 begin
-  LoadOpenSSL;
-
-  LPubKey := LoadPublicKey(APublicKey);
-  try
-    Result := InternalVerify(AInput, ASignature, LPubKey, AAlg);
-  finally
-    EVP_PKEY_free(LPubKey);
-  end;
+  Result := TJOSEProviders.ECDSA.Verify(AInput, ASignature, APublicKey, AAlg);
 end;
 
 class function TECDSA.VerifyPrivateKey(const AKey: TBytes): Boolean;
-var
-  LBio: PBIO;
-  LPrivKey: PEVP_PKEY;
 begin
-  LoadOpenSSL;
-
-  // Load Private Key
-  LBio := BIO_new(BIO_s_mem);
-  try
-    BIO_write(LBio, @AKey[0], Length(AKey));
-    LPrivKey := JoseSSL.PEM_read_bio_ECPrivateKey(LBio, nil, nil, nil);
-    Result := (LPrivKey <> nil);
-    if Result then
-      EVP_PKEY_free(LPrivKey);
-  finally
-    BIO_free(LBio);
-  end;
+  Result := TJOSEProviders.ECDSA.VerifyPrivateKey(AKey);
 end;
 
 class function TECDSA.VerifyPublicKey(const AKey: TBytes): Boolean;
-var
-  LBio: PBIO;
-  LKey: PEVP_PKEY;
 begin
-  LoadOpenSSL;
-
-  // Load Public Key
-  LBio := BIO_new(BIO_s_mem);
-  try
-    BIO_write(LBio, @AKey[0], Length(AKey));
-    LKey := JoseSSL.PEM_read_bio_PUBKEY(LBio, nil, nil, nil);
-
-    Result := (LKey <> nil);
-    if Result then
-      EVP_PKEY_free(LKey);
-  finally
-    BIO_free(LBio);
-  end;
+  Result := TJOSEProviders.ECDSA.VerifyPublicKey(AKey);
 end;
 
 class function TECDSA.VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TECDSAAlgorithm): Boolean;
-var
-  LKey: PEVP_PKEY;
 begin
-  LoadOpenSSL;
-
-  LKey := LoadPublicKeyFromCert(ACertificate, JoseSSL.NID_X9_62_id_ecPublicKey);
-  try
-    Result := InternalVerify(AInput, ASignature, LKey, AAlg);
-  finally
-    EVP_PKEY_free(LKey);
-  end;
+  Result := TJOSEProviders.ECDSA.VerifyWithCertificate(AInput, ASignature, ACertificate, AAlg);
 end;
 
 {$ENDIF}

--- a/Source/Common/JOSE.Signing.RSA.pas
+++ b/Source/Common/JOSE.Signing.RSA.pas
@@ -30,29 +30,14 @@ interface
 
 uses
   System.SysUtils,
-  IdGlobal, IdCTypes,
-  IdSSLOpenSSLHeaders,
-  JOSE.OpenSSL.Headers,
-  JOSE.Signing.Base,
-  JOSE.Encoding.Base64;
+  JOSE.Crypto.Algorithms,
+  JOSE.Signing.Base;
 
 type
-  TRSAAlgorithm = (RS256, RS384, RS512);
-  TRSAAlgorithmHelper = record helper for TRSAAlgorithm
-    procedure FromString(const AValue: string);
-    function ToString: string;
-  end;
+  TRSAAlgorithm = JOSE.Crypto.Algorithms.TRSAAlgorithm;
+  TRSAAlgorithmHelper = JOSE.Crypto.Algorithms.TRSAAlgorithmHelper;
 
   TRSA = class(TSigningBase)
-  private
-    class function RSAKeyFromEVP(AKey: PEVP_PKEY): PRSA;
-
-    class function LoadPublicKey(const AKey: TBytes): PRSA;
-    class function LoadPrivateKey(const AKey: TBytes): PRSA;
-    class function LoadRSAPublicKeyFromCert(const ACertificate: TBytes): PRSA;
-
-    class function InternalSign(const AInput: TBytes; AKey: PRSA; AAlg: TRSAAlgorithm): TBytes;
-    class function InternalVerify(const AInput, ASignature: TBytes; AKey: PRSA; AAlg: TRSAAlgorithm): Boolean;
   public
     class function Sign(const AInput, AKey: TBytes; AAlg: TRSAAlgorithm): TBytes;
     class function Verify(const AInput, ASignature, AKey: TBytes; AAlg: TRSAAlgorithm): Boolean;
@@ -68,265 +53,34 @@ implementation
 
 {$IFDEF RSA_SIGNING}
 
-{ TRSAAlgorithmHelper }
-
-procedure TRSAAlgorithmHelper.FromString(const AValue: string);
-begin
-  if AValue = 'RS256' then
-    Self := RS256
-  else if AValue = 'RS384' then
-    Self := RS384
-  else if AValue = 'RS512' then
-    Self := RS512
-  else
-    raise Exception.Create('Invalid RSA algorithm type');
-end;
-
-function TRSAAlgorithmHelper.ToString: string;
-begin
-  Result := '';
-  case Self of
-    RS256: Result := 'RS256';
-    RS384: Result := 'RS384';
-    RS512: Result := 'RS512';
-  end;
-end;
+uses
+  JOSE.Providers;
 
 { TRSA }
 
-class function TRSA.InternalSign(const AInput: TBytes; AKey: PRSA; AAlg: TRSAAlgorithm): TBytes;
-var
-  LHash: TBytes;
-  LNID: Integer;
-  LRsaLen: Integer;
-  LShaLen: Integer;
-begin
-  case AAlg of
-    RS256:
-    begin
-      LNID := JoseSSL.NID_sha256;
-      LShaLen := SHA256_DIGEST_LENGTH;
-      SetLength(LHash, LShaLen);
-      JoseSSL.SHA256(@AInput[0], Length(AInput), @LHash[0]);
-    end;
-    RS384:
-    begin
-      LNID := JoseSSL.NID_sha384;
-      LShaLen := SHA384_DIGEST_LENGTH;
-      SetLength(LHash, LShaLen);
-      JoseSSL.SHA384(@AInput[0], Length(AInput), @LHash[0]);
-    end;
-    RS512:
-    begin
-      LNID := JoseSSL.NID_sha512;
-      LShaLen := SHA512_DIGEST_LENGTH;
-      SetLength(LHash, LShaLen);
-      JoseSSL.SHA512(@AInput[0], Length(AInput), @LHash[0]);
-    end
-  else
-    raise ESignException.Create('[RSA] Unsupported signing algorithm!');
-  end;
-
-  LRsaLen := JoseSSL.RSA_size(AKey);
-  SetLength(Result, LRsaLen);
-  if JoseSSL.RSA_sign(LNID, @LHash[0], LShaLen, @Result[0], @LRsaLen, AKey) = 0 then
-    raise ESignException.Create('[RSA] Unable to sign RSA message digest');
-end;
-
-class function TRSA.InternalVerify(const AInput, ASignature: TBytes; AKey: PRSA; AAlg: TRSAAlgorithm): Boolean;
-var
-  LResult: Integer;
-  LHash: TBytes;
-  LNID: Integer;
-  LShaLen: Integer;
-begin
-  case AAlg of
-    RS256:
-    begin
-      LNID := JoseSSL.NID_sha256;
-      LShaLen := SHA256_DIGEST_LENGTH;
-      SetLength(LHash, LShaLen);
-      JoseSSL.SHA256(@AInput[0], Length(AInput), @LHash[0]);
-    end;
-    RS384:
-    begin
-      LNID := JoseSSL.NID_sha384;
-      LShaLen := SHA384_DIGEST_LENGTH;
-      SetLength(LHash, LShaLen);
-      JoseSSL.SHA384(@AInput[0], Length(AInput), @LHash[0]);
-    end;
-    RS512:
-    begin
-      LNID := JoseSSL.NID_sha512;
-      LShaLen := SHA512_DIGEST_LENGTH;
-      SetLength(LHash, LShaLen);
-      JoseSSL.SHA512(@AInput[0], Length(AInput), @LHash[0]);
-    end
-  else
-    raise ESignException.Create('[RSA] Unsupported signing algorithm!');
-  end;
-  LResult := JoseSSL.RSA_verify(LNID, @LHash[0], LShaLen, @ASignature[0], Length(ASignature), AKey);
-
-  Result := LResult = 1;
-end;
-
-class function TRSA.LoadPrivateKey(const AKey: TBytes): PRSA;
-var
-  LBio: PBIO;
-begin
-  // Load Private RSA Key into RSA object
-  LBio := BIO_new(BIO_s_mem);
-  try
-    BIO_write(LBio, @AKey[0], Length(AKey));
-    Result := PEM_read_bio_RSAPrivateKey(LBio, nil, nil, nil);
-    if Result = nil then
-      raise ESignException.Create('[RSA] Unable to load private key: ' + JOSESSL.GetLastError);
-  finally
-    BIO_free(LBio);
-  end;
-end;
-
-class function TRSA.LoadPublicKey(const AKey: TBytes): PRSA;
-var
-  LBio: PBIO;
-  LPubKey: TBytes;
-begin
-  // Load Public RSA Key into RSA object
-  LBio := BIO_new(BIO_s_mem);
-  try
-    if CompareMem(@PEM_X509_CERTIFICATE[0], @AKey[0], Length(PEM_X509_CERTIFICATE)) then
-    begin
-      LPubKey := Self.PublicKeyFromCertificate(AKey);
-      BIO_write(LBio, @LPubKey[0], Length(LPubKey));
-      Result := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
-    end else
-    begin
-      BIO_write(LBio, @AKey[0], Length(AKey));
-      if CompareMem(@PEM_PUBKEY_PKCS1[0], @AKey[0], Length(PEM_PUBKEY_PKCS1)) then
-        Result := PEM_read_bio_RSAPublicKey(LBio, nil, nil, nil)
-      else
-        Result := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
-    end;
-
-    if Result = nil then
-      raise ESignException.Create('[RSA] Unable to load public key: ' + JOSESSL.GetLastError);
-  finally
-    BIO_free(LBio);
-  end;
-end;
-
-class function TRSA.LoadRSAPublicKeyFromCert(const ACertificate: TBytes): PRSA;
-var
-  LKey: PEVP_PKEY;
-begin
-  LKey := LoadPublicKeyFromCert(ACertificate, NID_rsaEncryption);
-  try
-    Result := RSAKeyFromEVP(LKey);
-  finally
-    EVP_PKEY_free(LKey);
-  end;
-end;
-
-class function TRSA.RSAKeyFromEVP(AKey: PEVP_PKEY): PRSA;
-begin
-  Result := EVP_PKEY_get1_RSA(AKey);
-  if not Assigned(Result) then
-    raise ESignException.Create('[RSA] Error extracting RSA key from EVP_PKEY');
-end;
-
 class function TRSA.Sign(const AInput, AKey: TBytes; AAlg: TRSAAlgorithm): TBytes;
-var
-  LRsa: PRSA;
 begin
-  LoadOpenSSL;
-
-  LRsa := LoadPrivateKey(AKey);
-  try
-    Result := InternalSign(AInput, LRsa, AAlg);
-  finally
-    RSA_Free(LRsa);
-  end;
+  Result := TJOSEProviders.RSA.Sign(AInput, AKey, AAlg);
 end;
 
 class function TRSA.Verify(const AInput, ASignature, AKey: TBytes; AAlg: TRSAAlgorithm): Boolean;
-var
-  LRsa: PRSA;
 begin
-  LoadOpenSSL;
-
-  LRsa := LoadPublicKey(AKey);
-  try
-    Result := InternalVerify(AInput, ASignature, LRsa, AAlg);
-  finally
-    RSA_Free(LRsa);
-  end;
+  Result := TJOSEProviders.RSA.Verify(AInput, ASignature, AKey, AAlg);
 end;
 
 class function TRSA.VerifyPrivateKey(const AKey: TBytes): Boolean;
-var
-  LBio: PBIO;
-  LRsa: PRSA;
 begin
-  LoadOpenSSL;
-
-  // Load Private RSA Key
-  LBio := BIO_new(BIO_s_mem);
-  try
-    BIO_write(LBio, @AKey[0], Length(AKey));
-    LRsa := PEM_read_bio_RSAPrivateKey(LBio, nil, nil, nil);
-    Result := (LRsa <> nil);
-    if Result then
-      RSA_Free(LRsa);
-  finally
-    BIO_free(LBio);
-  end;
+  Result := TJOSEProviders.RSA.VerifyPrivateKey(AKey);
 end;
 
 class function TRSA.VerifyPublicKey(const AKey: TBytes): Boolean;
-var
-  LBio: PBIO;
-  LRsa: PRSA;
-  LPubKey: TBytes;
 begin
-  LoadOpenSSL;
-
-  // Load Public RSA Key
-  LBio := BIO_new(BIO_s_mem);
-  try
-    if CompareMem(@PEM_X509_CERTIFICATE[0], @AKey[0], Length(PEM_X509_CERTIFICATE)) then
-    begin
-      LPubKey := Self.PublicKeyFromCertificate(AKey);
-      BIO_write(LBio, @LPubKey[0], Length(LPubKey));
-      LRsa := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
-    end else
-    begin
-      BIO_write(LBio, @AKey[0], Length(AKey));
-      if CompareMem(@PEM_PUBKEY_PKCS1[0], @AKey[0], Length(PEM_PUBKEY_PKCS1)) then
-        LRsa := PEM_read_bio_RSAPublicKey(LBio, nil, nil, nil)
-      else
-        LRsa := JoseSSL.PEM_read_bio_RSA_PUBKEY(LBio, nil, nil, nil);
-    end;
-
-    Result := (LRsa <> nil);
-    if Result then
-      RSA_Free(LRsa);
-  finally
-    BIO_free(LBio);
-  end;
+  Result := TJOSEProviders.RSA.VerifyPublicKey(AKey);
 end;
 
 class function TRSA.VerifyWithCertificate(const AInput, ASignature, ACertificate: TBytes; AAlg: TRSAAlgorithm): Boolean;
-var
-  LRsa: PRSA;
 begin
-  LoadOpenSSL;
-
-  LRsa := LoadRSAPublicKeyFromCert(ACertificate);
-  try
-    Result := InternalVerify(AInput, ASignature, LRsa, AAlg);
-  finally
-    RSA_free(LRsa);
-  end;
+  Result := TJOSEProviders.RSA.VerifyWithCertificate(AInput, ASignature, ACertificate, AAlg);
 end;
 
 {$ENDIF}

--- a/Source/JOSE/JOSE.Core.JWS.pas
+++ b/Source/JOSE/JOSE.Core.JWS.pas
@@ -95,7 +95,7 @@ uses
   System.Types,
   System.StrUtils,
   JOSE.Types.JSON,
-  JOSE.Signing.Base,
+  JOSE.Providers,
   JOSE.Encoding.Base64,
   JOSE.Hashing.HMAC,
   JOSE.Core.JWA.Factory;
@@ -240,7 +240,7 @@ end;
 {$IFDEF RSA_SIGNING}
 procedure TJWS.SetKeyFromCert(const ACert: TJOSEBytes);
 begin
-  FKey.AsBytes := TSigningBase.PublicKeyFromCertificate(ACert.AsBytes);
+  FKey.AsBytes := TJOSEProviders.Certificate.PublicKeyFromCertificate(ACert.AsBytes);
 end;
 {$ENDIF}
 

--- a/Tests/Source/JOSE.Tests.Common.pas
+++ b/Tests/Source/JOSE.Tests.Common.pas
@@ -28,7 +28,6 @@ uses
   
   JOSE.Types.Bytes,
   JOSE.Hashing.HMAC,
-  JOSE.Signing.RSA,
   JOSE.Types.Arrays,
   JOSE.Types.JSON,
   JOSE.Encoding.Base64,
@@ -98,7 +97,7 @@ type
     procedure TestSignSHA384(const AValue1, AValue2, _Expected: string);
 
     [Test]
-    [TestCase('TestSignSHA512', 'plaintext,secret,3/adkEcz1vmOINXEEOxdtM119BDAnKgvIJyr7IxLpdQsaUWLu9vu1Wz4veWeKz7wrkKTzySUGFj6'#$D#$A'/rDBrJzRuQ==')]
+    [TestCase('TestSignSHA512', 'plaintext,secret,3/adkEcz1vmOINXEEOxdtM119BDAnKgvIJyr7IxLpdQsaUWLu9vu1Wz4veWeKz7wrkKTzySUGFj6/rDBrJzRuQ==')]
     procedure TestSignSHA512(const AValue1, AValue2, _Expected: string);
   end;
 

--- a/Tests/Source/JOSE.Tests.CryptoLib.pas
+++ b/Tests/Source/JOSE.Tests.CryptoLib.pas
@@ -71,6 +71,7 @@ end;
 procedure TTestCryptoLibProviders.TearDown;
 begin
   TJOSECryptoLibProviders.Unregister;
+  TJOSEProviders.RegisterProvider;
   inherited;
 end;
 

--- a/Tests/Source/JOSE.Tests.CryptoLib.pas
+++ b/Tests/Source/JOSE.Tests.CryptoLib.pas
@@ -1,0 +1,127 @@
+{******************************************************************************}
+{                                                                              }
+{  Delphi JOSE Library                                                         }
+{  Copyright (c) 2015 Paolo Rossi                                              }
+{  https://github.com/paolo-rossi/delphi-jose-jwt                              }
+{                                                                              }
+{******************************************************************************}
+{                                                                              }
+{  Licensed under the Apache License, Version 2.0 (the "License");             }
+{  you may not use this file except in compliance with the License.            }
+{  You may obtain a copy of the License at                                     }
+{                                                                              }
+{      http://www.apache.org/licenses/LICENSE-2.0                              }
+{                                                                              }
+{  Unless required by applicable law or agreed to in writing, software         }
+{  distributed under the License is distributed on an "AS IS" BASIS,           }
+{  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.    }
+{  See the License for the specific language governing permissions and         }
+{  limitations under the License.                                              }
+{                                                                              }
+{******************************************************************************}
+
+unit JOSE.Tests.CryptoLib;
+
+interface
+
+uses
+  DUnitX.TestFramework,
+
+  JOSE.Tests.Classes,
+  JOSE.Core.JWT,
+  JOSE.Core.JWS,
+  JOSE.Core.JWA,
+  JOSE.Signing.RSA,
+  JOSE.Signing.ECDSA,
+  JOSE.Providers,
+  JOSE.Providers.CryptoLib,
+  JOSE.Hashing.HMAC,
+  JOSE.Crypto.Algorithms,
+  JOSE.Encoding.Base64;
+
+type
+  [TestFixture]
+  [Category('CryptoLib')]
+  TTestCryptoLibProviders = class(TTestBase)
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+    [Test]
+    procedure TestHMAC_SHA256_Vector;
+    [Test]
+    procedure TestRSA_RS256_SignVerifyRoundTrip;
+    [Test]
+    procedure TestECDSA_Verify_ES256_Token;
+  end;
+
+implementation
+
+uses
+  System.SysUtils,
+  System.IOUtils;
+
+procedure TTestCryptoLibProviders.Setup;
+begin
+  inherited;
+  TJOSECryptoLibProviders.Register;
+end;
+
+procedure TTestCryptoLibProviders.TearDown;
+begin
+  TJOSECryptoLibProviders.Unregister;
+  inherited;
+end;
+
+procedure TTestCryptoLibProviders.TestHMAC_SHA256_Vector;
+var
+  LSig, LExpected: TBytes;
+begin
+  LSig := THMAC.Sign(TEncoding.ANSI.GetBytes('plaintext'), TEncoding.ANSI.GetBytes('secret'), THMACAlgorithm.SHA256);
+  LExpected := TBase64.Decode('XXv4q83DfQItSR7PCiZwWFlG10ah668c1cRsrKh6Ylg=').AsBytes;
+  Assert.AreEqualMemory(@LExpected[0], @LSig[0], Length(LExpected));
+end;
+
+procedure TTestCryptoLibProviders.TestRSA_RS256_SignVerifyRoundTrip;
+var
+  LPriv, LPub, LInput: TBytes;
+  LSig: TBytes;
+begin
+  LPriv := TFile.ReadAllBytes(TPath.Combine(FKeysPath, 'rsa-private.pem'));
+  LPub := TFile.ReadAllBytes(TPath.Combine(FKeysPath, 'rsa-public.pem'));
+  LInput := TEncoding.UTF8.GetBytes('The quick brown fox');
+  LSig := TRSA.Sign(LInput, LPriv, TRSAAlgorithm.RS256);
+  Assert.IsTrue(TRSA.Verify(LInput, LSig, LPub, TRSAAlgorithm.RS256));
+end;
+
+procedure TTestCryptoLibProviders.TestECDSA_Verify_ES256_Token;
+const
+  TOKEN_ES256 =
+    'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.' +
+    'eyJpYXQiOjE1MTYyMzkwMjIsImV4cCI6MTUxNjI0OTAyMiwiaXNzIjoiRGVscGhpIEpPU0UgYW5kIEpXVCBMaWJyYXJ5In0.' +
+    '4QDMKAvHwb6pA5fN0oQjlzuKmPIlNpmIQ8vPH7zy4fjZdtcPVJMtfiVhztwQldQL9A5yzBKI8q2puVygm-2Adw';
+var
+  LToken: TJWT;
+  LSigner: TJWS;
+begin
+  LToken := TJWT.Create;
+  try
+    LSigner := TJWS.Create(LToken);
+    try
+      LSigner.SetKey(TFile.ReadAllBytes(TPath.Combine(FKeysPath, 'es256-public.pem')));
+      LSigner.SkipKeyValidation := True;
+      LSigner.CompactToken := TOKEN_ES256;
+      Assert.IsTrue(LSigner.VerifySignature, 'ES256 (CryptoLib) should validate');
+    finally
+      LSigner.Free;
+    end;
+  finally
+    LToken.Free;
+  end;
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestCryptoLibProviders);
+
+end.


### PR DESCRIPTION
Implements the "bring your own providers" pattern proposed in issue #94. Cryptographic operations (HMAC, RSA, ECDSA, certificate handling) and Base64/Base64URL encoding are now resolved at runtime through interfaces rather than being hard-wired to OpenSSL/Indy and `System.NetEncoding`. Existing callers continue to work unchanged — the default OpenSSL stack is registered automatically at unit initialization.

## What's added

- **`JOSE.Providers.Interfaces`** — narrow interfaces (`IJOSEBase64Provider`, `IJOSEHmacProvider`, and under `RSA_SIGNING`: `IJOSECertificateProvider`, `IJOSESignerRSA`, `IJOSESignerECDSA`).
- **`JOSE.Providers`** — central `TJOSEProviders` registry with class properties for each slot, plus `RegisterProvider` / `UnregisterProvider` helpers and an `EJOSEProvidersNotRegistered` guard.
- **`JOSE.Providers.Default`** — the existing OpenSSL/Indy/`System.NetEncoding` code refactored into default provider classes; registered automatically from `initialization`.
- **`JOSE.Providers.CryptoLib`** — a fully working [CryptoLib4Pascal](https://github.com/Xor-el/CryptoLib4Pascal) backend (Base64 via `SbpBase64`, HMAC via `TMacUtilities`, RSA/ECDSA signers via `TSignerUtilities`, certificate parsing via `TX509CertificateParser`). Demonstrates the pattern and gives users a non-OpenSSL option.
- **`JOSE.Crypto.Algorithms`** — algorithm enums (`THMACAlgorithm`, `TRSAAlgorithm`, `TECDSAAlgorithm`) and a new `TJOSECertificatePublicKey = (RSA, EC)` enum lifted out of the signing units. The old units re-export the types so existing code compiles.

## What's refactored

- `JOSE.Encoding.Base64`, `JOSE.Hashing.HMAC`, `JOSE.Signing.RSA`, `JOSE.Signing.ECDSA`, and `JOSE.Signing.Base` are reduced to thin facades that delegate to the active provider. All OpenSSL machinery moves into `JOSE.Providers.Default`.
- `VerifyCertificate` and friends now take the new `TJOSECertificatePublicKey` enum instead of raw OpenSSL NIDs, so the API no longer leaks OpenSSL constants. Sample code (`Crypto.Form.RSA`, `Crypto.Form.ECDSA`) is updated accordingly, and stray `TECDSA.LoadOpenSSL` calls are removed.
- `JOSE.Core.JWS.SetKeyFromCert` now goes through `TJOSEProviders.Certificate`.
- All five package files (10.1 Berlin through 11+) include the four new units.

## Tests

- `JOSE.Tests.CryptoLib` — registers `TJOSECryptoLibProviders` in setup, runs HMAC-SHA256 vector, RSA RS256 sign/verify round-trip, and ES256 token verification, then restores the default stack in teardown.
- A whitespace fix in `JOSE.Tests.Common` corrects a stray CRLF in an HMAC-SHA512 expected value.

## Behaviour

Zero breaking changes for existing users — `TJOSEProviders.RegisterProvider` runs at startup and wires up the default OpenSSL/Indy stack. Swapping backends is a one-liner:

```pascal
TJOSECryptoLibProviders.Register;  // now everything uses CryptoLib4Pascal
```