### PR TITLE
CryptoLib4Pascal-backed JWK key material, plus two key-material fixes in the OpenSSL provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Since [PR #95](https://github.com/paolo-rossi/delphi-jose-jwt/pull/95), every cr
 | --------------- | ---- | ---------------- | ----- |
 | `TJOSEDefaultProviders` (default) | `JOSE.Providers.Default` | OpenSSL 1.0.x/1.1.x (via Indy) | Registered automatically at startup. Needs the OpenSSL DLLs for RSA/ECDSA (see [OpenSSL requirements](#important-openssl-requirements) above). Pokes a few raw OpenSSL struct fields internally, so it does **not** work against OpenSSL 3.x/4.x (those structs are opaque) — use `TJOSETaurusTLSProviders` for that. Implements [JWK](#json-web-key-jwk-support) PEM import/export |
 | `TJOSETaurusTLSProviders` | `JOSE.Providers.TaurusTLS` | OpenSSL 1.1.x/3.x/4.x, via the [TaurusTLS](https://github.com/JPeterMugaas/TaurusTLS) binding for Indy (vendored under `Libs\TaurusTLS`) | Only touches OpenSSL through accessor functions (`RSA_get0_key`/`RSA_set0_key`, `EC_KEY_get0_public_key`, `EC_POINT_get/set_affine_coordinates`, ...), so it's forward-compatible as OpenSSL's structs get more opaque. TaurusTLS itself already probes for `-4` (OpenSSL 4.x) DLLs before falling back to `-3`/`-1_1`/`-1`. Implements [JWK](#json-web-key-jwk-support) PEM import/export. Not part of the `.dpk` package `contains` list — add `Libs\TaurusTLS`'s runtime package and `JOSE.Providers.TaurusTLS.pas` to your project manually, plus OpenSSL 3.x/4.x binaries (see `Libs\TaurusTLS\OpenSSL\binaries\README.md` for where to get them) |
-| `TJOSECryptoLibProviders` | `JOSE.Providers.CryptoLib` | pure-Pascal [CryptoLib4Pascal](https://github.com/Xor-el/CryptoLib4Pascal) | No native OpenSSL DLLs needed at all. Not part of the `.dpk` package `contains` list — add `JOSE.Providers.CryptoLib.pas` and a CryptoLib4Pascal dependency to your project manually if you want it |
+| `TJOSECryptoLibProviders` | `JOSE.Providers.CryptoLib` | pure-Pascal [CryptoLib4Pascal](https://github.com/Xor-el/CryptoLib4Pascal) | No native OpenSSL DLLs needed at all. Implements [JWK](#json-web-key-jwk-support) PEM import/export. Not part of the `.dpk` package `contains` list — add `JOSE.Providers.CryptoLib.pas` and a CryptoLib4Pascal dependency to your project manually if you want it |
 
 Switching to the TaurusTLS-backed stack (OpenSSL 3.x/4.x) or the CryptoLib4Pascal-backed stack (and back):
 
@@ -94,7 +94,7 @@ TJOSEProviders.ECDSA := TMyHSMBackedECDSAProvider.Create;
 | `IJOSERSAKeyMaterialProvider` | Raw RSA key import/export to/from PEM ([JWK](#json-web-key-jwk-support) support) |
 | `IJOSEECKeyMaterialProvider` | Raw EC key import/export to/from PEM ([JWK](#json-web-key-jwk-support) support) |
 
-`RSAKeyMaterial`/`ECKeyMaterial` are optional — a provider stack doesn't need to implement them unless you call `TJSONWebKey.FromPEM`/`ToPEM`. Registering a stack without them (like `TJOSECryptoLibProviders` today) doesn't affect ordinary RSA/ECDSA signing; it just means `FromPEM`/`ToPEM` will raise until you either switch back to the default stack or provide your own implementation.
+`RSAKeyMaterial`/`ECKeyMaterial` are optional — a provider stack doesn't need to implement them unless you call `TJSONWebKey.FromPEM`/`ToPEM`. Every stack that ships with the library implements both, but if you assign providers individually and leave these two unset, ordinary RSA/ECDSA signing is unaffected; it just means `FromPEM`/`ToPEM` will raise until you supply an implementation.
 
 ## :question: What is JOSE
 
@@ -165,7 +165,7 @@ Full [RFC 7517](https://tools.ietf.org/html/rfc7517) JSON Web Key support, via `
 - `TJSONWebKeySet` for JWKS documents (`AddKey`, `FindByKid`, JSON round-trip)
 - A bridge (`ToKeyPair`/`FromKeyPair`) to the legacy `TJWK`/`TKeyPair` types, so a `TJSONWebKey` can be handed straight to `TJOSE.Sign`/`TJOSE.Verify`/`TJOSEProducer`
 
-PEM import/export is backed by the [crypto provider](#custom-crypto-providers-bring-your-own-crypto) currently registered; today that means the OpenSSL-backed default stack (see the table above).
+PEM import/export is backed by the [crypto provider](#custom-crypto-providers-bring-your-own-crypto) currently registered — every stack in the table above supports it, so `FromPEM`/`ToPEM` works with or without OpenSSL.
 
 #### Import a PEM key and sign a token with it
 
@@ -240,7 +240,6 @@ end;
 ##### Features
 - JWE support (there is partial implementation in [this PR](https://github.com/paolo-rossi/delphi-jose-jwt/pull/84))
 - More crypto providers on top of the [provider abstraction](#custom-crypto-providers-bring-your-own-crypto) (e.g. TMS Cryptography Pack) — OpenSSL and [CryptoLib4Pascal](https://github.com/Xor-el/CryptoLib4Pascal) are supported today
-- A CryptoLib4Pascal-backed `IJOSERSAKeyMaterialProvider`/`IJOSEECKeyMaterialProvider` implementation, so [JWK](#json-web-key-jwk-support) PEM import/export works without OpenSSL too (OpenSSL-backed provider only, for now)
 
 ##### Code
 - More unit tests

--- a/Source/Common/JOSE.Providers.CryptoLib.pas
+++ b/Source/Common/JOSE.Providers.CryptoLib.pas
@@ -97,9 +97,26 @@ type
     function VerifyPrivateKey(const AKey: TBytes): Boolean;
   end;
 
+  /// <summary>CryptoLib-backed raw RSA key import/export (JWK PEM support).</summary>
+  TCryptoLibRSAKeyMaterialProvider = class(TInterfacedObject, IJOSERSAKeyMaterialProvider)
+  public
+    function ImportPEM(const APEM: TBytes): TJOSERSAKeyMaterial;
+    function ExportPEM(const AKeyMaterial: TJOSERSAKeyMaterial; AIncludePrivate: Boolean): TBytes;
+  end;
+
+  /// <summary>CryptoLib-backed raw EC key import/export (JWK PEM support).</summary>
+  TCryptoLibECKeyMaterialProvider = class(TInterfacedObject, IJOSEECKeyMaterialProvider)
+  strict private
+    class function CurveToOid(ACurve: TECCurve): IDerObjectIdentifier; static;
+    class function OidToCurve(const AOid: IDerObjectIdentifier): TECCurve; static;
+  public
+    function ImportPEM(const APEM: TBytes): TJOSEECKeyMaterial;
+    function ExportPEM(const AKeyMaterial: TJOSEECKeyMaterial; AIncludePrivate: Boolean): TBytes;
+  end;
+
   TJOSECryptoLibProviders = class
   public
-    /// <summary>Wires CryptoLib implementations into <see cref="JOSE.Providers|TJOSEProviders"/> (Base64, HMAC, cert, RSA, ECDSA).</summary>
+    /// <summary>Wires CryptoLib implementations into <see cref="JOSE.Providers|TJOSEProviders"/> (Base64, HMAC, cert, RSA, ECDSA, key material).</summary>
     class procedure Register; static;
     /// <summary>Clears <see cref="JOSE.Providers|TJOSEProviders"/> slots previously set by <see cref="Register"/>.</summary>
     class procedure Unregister; static;
@@ -130,7 +147,13 @@ uses
   ClpX9ObjectIdentifiers,
   ClpSecObjectIdentifiers,
   ClpIRsaParameters,
+  ClpRsaParameters,
   ClpIECParameters,
+  ClpECParameters,
+  ClpECGenerators,
+  ClpIECCommon,
+  ClpBigInteger,
+  ClpBigIntegerUtilities,
   SbpBase64,
   JOSE.Signing.Base;
 
@@ -158,6 +181,17 @@ resourcestring
   SJOSECryptoLibKeyNotECPublic = '[CryptoLib] Key is not an EC public key';
   SJOSECryptoLibKeyNotECPrivate = '[CryptoLib] Key is not an EC private key';
   SJOSECryptoLibECDSASignError = '[CryptoLib] ECDSA sign error: %s';
+  SJOSECryptoLibJWKEmptyPEMData = '[CryptoLib][JWK] Empty PEM data';
+  SJOSECryptoLibJWKExpectedKeyPEM = '[CryptoLib][JWK] Expected a key PEM, not an X.509 certificate PEM';
+  SJOSECryptoLibJWKNoKeyInPEM = '[CryptoLib][JWK] PEM does not contain a key';
+  SJOSECryptoLibJWKPEMNotRSA = '[CryptoLib][JWK] PEM does not contain an RSA key';
+  SJOSECryptoLibJWKPEMNotEC = '[CryptoLib][JWK] PEM does not contain an EC key';
+  SJOSECryptoLibJWKRSANoCRT = '[CryptoLib][JWK] RSA private key has no CRT components (public exponent unavailable)';
+  SJOSECryptoLibJWKECNoNamedCurve = '[CryptoLib][JWK] EC key does not use a named curve';
+  SJOSECryptoLibJWKMissingComponent = '[CryptoLib][JWK] Missing required key component [%s]';
+  SJOSECryptoLibJWKUnsupportedECCurve = '[CryptoLib][JWK] Unsupported EC curve';
+  SJOSECryptoLibJWKUnsupportedECCurveOID = '[CryptoLib][JWK] Unsupported EC curve (OID %s)';
+  SJOSECryptoLibJWKWritePEMError = '[CryptoLib][JWK] Unable to write the key PEM: %s';
 
 { TJOSECryptoLibPem }
 
@@ -175,7 +209,65 @@ type
     /// </summary>
     class function ReadPublicKey(const APem: TBytes; const ACertProvider: IJOSECertificateProvider;
       ACertExpected: TJOSECertificatePublicKey): IAsymmetricKeyParameter; static;
+    /// <summary>
+    /// Reads whichever key halves a PEM carries, for the key-material (JWK) providers: a key pair
+    /// PEM yields both, a lone private/public key PEM yields that one and leaves the other nil.
+    /// Unlike <see cref="ReadPrivateKey"/>/<see cref="ReadPublicKey"/> it accepts either kind, and
+    /// never accepts a certificate.
+    /// </summary>
+    class procedure ReadKeyMaterial(const APem: TBytes; out APrivateKey, APublicKey: IAsymmetricKeyParameter); static;
+    /// <summary>Writes any asymmetric key as PEM: RSA private keys as PKCS#1, EC private keys as
+    ///   SEC1, public keys as SPKI, which is what <c>TOpenSslPemWriter</c> emits per key type.</summary>
+    class function WriteKey(const AKey: IAsymmetricKeyParameter): TBytes; static;
   end;
+
+  /// <summary>Plumbing shared by the two key-material (JWK) providers.</summary>
+  TJOSECryptoLibKeyMaterial = class
+  public
+    /// <summary>The half of a decoded PEM that carries the most key material: a private key
+    ///   determines every JWK component, a public key only the public ones.</summary>
+    class function SelectKey(const APrivateKey, APublicKey: IAsymmetricKeyParameter): IAsymmetricKeyParameter; static;
+    /// <summary>Converts a required JWK key component, naming it in the error when it is absent.</summary>
+    class function RequiredComponent(const AValue: TBytes; const AName: string): TBigInteger; static;
+  end;
+
+class function TJOSECryptoLibPem.WriteKey(const AKey: IAsymmetricKeyParameter): TBytes;
+var
+  LStream: TMemoryStream;
+  LWriter: TOpenSslPemWriter;
+begin
+  LStream := TMemoryStream.Create;
+  try
+    LWriter := TOpenSslPemWriter.Create(LStream);
+    try
+      LWriter.WriteObject(TValue.From<IAsymmetricKeyParameter>(AKey));
+    finally
+      LWriter.Free;
+    end;
+    SetLength(Result, LStream.Size);
+    if LStream.Size > 0 then
+      Move(LStream.Memory^, Result[0], LStream.Size);
+  finally
+    LStream.Free;
+  end;
+end;
+
+{ TJOSECryptoLibKeyMaterial }
+
+class function TJOSECryptoLibKeyMaterial.SelectKey(const APrivateKey, APublicKey: IAsymmetricKeyParameter): IAsymmetricKeyParameter;
+begin
+  if Assigned(APrivateKey) then
+    Result := APrivateKey
+  else
+    Result := APublicKey;
+end;
+
+class function TJOSECryptoLibKeyMaterial.RequiredComponent(const AValue: TBytes; const AName: string): TBigInteger;
+begin
+  if Length(AValue) = 0 then
+    raise ESignException.CreateFmt(SJOSECryptoLibJWKMissingComponent, [AName]);
+  Result := TBigIntegerUtilities.FromUnsignedByteArray(AValue);
+end;
 
 { TCryptoLibBase64Provider }
 
@@ -374,6 +466,54 @@ begin
   end;
 end;
 
+class procedure TJOSECryptoLibPem.ReadKeyMaterial(const APem: TBytes; out APrivateKey, APublicKey: IAsymmetricKeyParameter);
+var
+  LStream: TStringStream;
+  LReader: TOpenSslPemReader;
+  LVal: TValue;
+  LKp: IAsymmetricCipherKeyPair;
+  LCert: IX509Certificate;
+  LKey: IAsymmetricKeyParameter;
+begin
+  APrivateKey := nil;
+  APublicKey := nil;
+
+  LStream := TStringStream.Create(TEncoding.ASCII.GetString(APem));
+  try
+    LReader := TOpenSslPemReader.Create(LStream);
+    try
+      LVal := LReader.ReadObject();
+      if LVal.IsEmpty then
+        raise ESignException.Create(SJOSECryptoLibEmptyPEMObject);
+      if LVal.TryAsType<IX509Certificate>(LCert) and (LCert <> nil) then
+        raise ESignException.Create(SJOSECryptoLibJWKExpectedKeyPEM);
+
+      // A PKCS#1/SEC1 private key PEM decodes to a key pair, a PKCS#8 or SPKI PEM to a lone key.
+      if LVal.TryAsType<IAsymmetricKeyParameter>(LKey) and (LKey <> nil) then
+      begin
+        if LKey.IsPrivate then
+          APrivateKey := LKey
+        else
+          APublicKey := LKey;
+        Exit;
+      end;
+
+      if LVal.TryAsType<IAsymmetricCipherKeyPair>(LKp) and (LKp <> nil) then
+      begin
+        APrivateKey := LKp.Private;
+        APublicKey := LKp.Public;
+        Exit;
+      end;
+
+      raise ESignException.Create(SJOSECryptoLibJWKNoKeyInPEM);
+    finally
+      LReader.Free;
+    end;
+  finally
+    LStream.Free;
+  end;
+end;
+
 { TCryptoLibCertificateProvider }
 
 function TCryptoLibCertificateProvider.ExpectedCertPkAlg(AExpected: TJOSECertificatePublicKey): IDerObjectIdentifier;
@@ -389,24 +529,8 @@ begin
 end;
 
 function TCryptoLibCertificateProvider.WritePublicKeyPem(const APublicKey: IAsymmetricKeyParameter): TBytes;
-var
-  LStream: TMemoryStream;
-  LWriter: TOpenSslPemWriter;
 begin
-  LStream := TMemoryStream.Create;
-  try
-    LWriter := TOpenSslPemWriter.Create(LStream);
-    try
-      LWriter.WriteObject(TValue.From<IAsymmetricKeyParameter>(APublicKey));
-    finally
-      LWriter.Free;
-    end;
-    SetLength(Result, LStream.Size);
-    if LStream.Size > 0 then
-      Move(LStream.Memory^, Result[0], LStream.Size);
-  finally
-    LStream.Free;
-  end;
+  Result := TJOSECryptoLibPem.WriteKey(APublicKey);
 end;
 
 function TCryptoLibCertificateProvider.PublicKeyFromCertificate(const ACertificate: TBytes): TBytes;
@@ -718,6 +842,184 @@ begin
   end;
 end;
 
+{ TCryptoLibRSAKeyMaterialProvider }
+
+function TCryptoLibRSAKeyMaterialProvider.ImportPEM(const APEM: TBytes): TJOSERSAKeyMaterial;
+var
+  LPrivate, LPublic, LKey: IAsymmetricKeyParameter;
+  LRsa: IRsaKeyParameters;
+  LCrt: IRsaPrivateCrtKeyParameters;
+begin
+  Result := Default(TJOSERSAKeyMaterial);
+
+  if Length(APEM) = 0 then
+    raise ESignException.Create(SJOSECryptoLibJWKEmptyPEMData);
+
+  TJOSECryptoLibPem.ReadKeyMaterial(APEM, LPrivate, LPublic);
+  LKey := TJOSECryptoLibKeyMaterial.SelectKey(LPrivate, LPublic);
+
+  if not Supports(LKey, IRsaKeyParameters, LRsa) then
+    raise ESignException.Create(SJOSECryptoLibJWKPEMNotRSA);
+
+  Result.Modulus := TBigIntegerUtilities.AsUnsignedByteArray(LRsa.Modulus);
+
+  if not LRsa.IsPrivate then
+  begin
+    Result.PublicExponent := TBigIntegerUtilities.AsUnsignedByteArray(LRsa.Exponent);
+    Exit;
+  end;
+
+  // A private RSA key only carries the public exponent in its CRT form, which is what every PEM
+  // encoding CryptoLib can read (PKCS#1 and PKCS#8 alike) produces.
+  if not Supports(LKey, IRsaPrivateCrtKeyParameters, LCrt) then
+    raise ESignException.Create(SJOSECryptoLibJWKRSANoCRT);
+
+  Result.PublicExponent := TBigIntegerUtilities.AsUnsignedByteArray(LCrt.PublicExponent);
+  Result.PrivateExponent := TBigIntegerUtilities.AsUnsignedByteArray(LCrt.Exponent);
+  Result.P := TBigIntegerUtilities.AsUnsignedByteArray(LCrt.P);
+  Result.Q := TBigIntegerUtilities.AsUnsignedByteArray(LCrt.Q);
+  Result.DP := TBigIntegerUtilities.AsUnsignedByteArray(LCrt.DP);
+  Result.DQ := TBigIntegerUtilities.AsUnsignedByteArray(LCrt.DQ);
+  Result.QI := TBigIntegerUtilities.AsUnsignedByteArray(LCrt.QInv);
+end;
+
+function TCryptoLibRSAKeyMaterialProvider.ExportPEM(const AKeyMaterial: TJOSERSAKeyMaterial; AIncludePrivate: Boolean): TBytes;
+var
+  LKey: IAsymmetricKeyParameter;
+  LWritePrivate: Boolean;
+begin
+  LWritePrivate := AIncludePrivate and AKeyMaterial.IsPrivate;
+
+  if LWritePrivate then
+    LKey := TRsaPrivateCrtKeyParameters.Create(
+      TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.Modulus, 'n'),
+      TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.PublicExponent, 'e'),
+      TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.PrivateExponent, 'd'),
+      TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.P, 'p'),
+      TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.Q, 'q'),
+      TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.DP, 'dp'),
+      TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.DQ, 'dq'),
+      TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.QI, 'qi'))
+  else
+    LKey := TRsaKeyParameters.Create(False,
+      TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.Modulus, 'n'),
+      TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.PublicExponent, 'e'));
+
+  try
+    Result := TJOSECryptoLibPem.WriteKey(LKey);
+  except
+    on E: ESignException do
+      raise;
+    on E: Exception do
+      raise ESignException.CreateFmt(SJOSECryptoLibJWKWritePEMError, [E.Message]);
+  end;
+end;
+
+{ TCryptoLibECKeyMaterialProvider }
+
+class function TCryptoLibECKeyMaterialProvider.CurveToOid(ACurve: TECCurve): IDerObjectIdentifier;
+begin
+  case ACurve of
+    TECCurve.P256:      Result := TSecObjectIdentifiers.SecP256r1;
+    TECCurve.P384:      Result := TSecObjectIdentifiers.SecP384r1;
+    TECCurve.P521:      Result := TSecObjectIdentifiers.SecP521r1;
+    TECCurve.secp256k1: Result := TSecObjectIdentifiers.SecP256k1;
+  else
+    raise ESignException.Create(SJOSECryptoLibJWKUnsupportedECCurve);
+  end;
+end;
+
+class function TCryptoLibECKeyMaterialProvider.OidToCurve(const AOid: IDerObjectIdentifier): TECCurve;
+begin
+  if AOid = nil then
+    raise ESignException.Create(SJOSECryptoLibJWKECNoNamedCurve);
+
+  if AOid.ID = TSecObjectIdentifiers.SecP256r1.ID then
+    Result := TECCurve.P256
+  else if AOid.ID = TSecObjectIdentifiers.SecP384r1.ID then
+    Result := TECCurve.P384
+  else if AOid.ID = TSecObjectIdentifiers.SecP521r1.ID then
+    Result := TECCurve.P521
+  else if AOid.ID = TSecObjectIdentifiers.SecP256k1.ID then
+    Result := TECCurve.secp256k1
+  else
+    raise ESignException.CreateFmt(SJOSECryptoLibJWKUnsupportedECCurveOID, [AOid.ID]);
+end;
+
+function TCryptoLibECKeyMaterialProvider.ImportPEM(const APEM: TBytes): TJOSEECKeyMaterial;
+var
+  LPrivate, LPublic, LKey: IAsymmetricKeyParameter;
+  LEc: IECKeyParameters;
+  LEcPublic: IECPublicKeyParameters;
+  LEcPrivate: IECPrivateKeyParameters;
+  LPoint: IECPoint;
+begin
+  Result := Default(TJOSEECKeyMaterial);
+
+  if Length(APEM) = 0 then
+    raise ESignException.Create(SJOSECryptoLibJWKEmptyPEMData);
+
+  TJOSECryptoLibPem.ReadKeyMaterial(APEM, LPrivate, LPublic);
+  LKey := TJOSECryptoLibKeyMaterial.SelectKey(LPrivate, LPublic);
+
+  if not Supports(LKey, IECKeyParameters, LEc) then
+    raise ESignException.Create(SJOSECryptoLibJWKPEMNotEC);
+
+  Result.Curve := OidToCurve(LEc.PublicKeyParamSet);
+
+  // RFC 7518 6.2.2.1: "d" is the order-sized octet string, not the minimal encoding.
+  if Supports(LPrivate, IECPrivateKeyParameters, LEcPrivate) then
+    Result.D := TBigIntegerUtilities.AsUnsignedByteArray(
+      (LEcPrivate.Parameters.N.BitLength + 7) div 8, LEcPrivate.D);
+
+  // A PKCS#8 EC private key PEM decodes to a lone private key, so the public point has to be
+  // recovered from the scalar.
+  if Supports(LPublic, IECPublicKeyParameters, LEcPublic) then
+    LPoint := LEcPublic.Q
+  else if Assigned(LEcPrivate) then
+    LPoint := TECKeyPairGenerator.GetCorrespondingPublicKey(LEcPrivate).Q
+  else
+    raise ESignException.Create(SJOSECryptoLibJWKPEMNotEC);
+
+  LPoint := LPoint.Normalize;
+  Result.X := LPoint.AffineXCoord.GetEncoded;
+  Result.Y := LPoint.AffineYCoord.GetEncoded;
+end;
+
+function TCryptoLibECKeyMaterialProvider.ExportPEM(const AKeyMaterial: TJOSEECKeyMaterial; AIncludePrivate: Boolean): TBytes;
+var
+  LOid: IDerObjectIdentifier;
+  LDomain: IECNamedDomainParameters;
+  LPoint: IECPoint;
+  LKey: IAsymmetricKeyParameter;
+  LWritePrivate: Boolean;
+begin
+  LWritePrivate := AIncludePrivate and AKeyMaterial.IsPrivate;
+
+  LOid := CurveToOid(AKeyMaterial.Curve);
+  LDomain := TECNamedDomainParameters.LookupOid(LOid);
+
+  // Built for both branches: it validates x/y against the curve even when the private scalar is
+  // what ends up in the PEM.
+  LPoint := LDomain.Curve.CreatePoint(
+    TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.X, 'x'),
+    TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.Y, 'y'));
+
+  if LWritePrivate then
+    LKey := TECPrivateKeyParameters.Create('EC', TJOSECryptoLibKeyMaterial.RequiredComponent(AKeyMaterial.D, 'd'), LOid)
+  else
+    LKey := TECPublicKeyParameters.Create('EC', LPoint, LOid);
+
+  try
+    Result := TJOSECryptoLibPem.WriteKey(LKey);
+  except
+    on E: ESignException do
+      raise;
+    on E: Exception do
+      raise ESignException.CreateFmt(SJOSECryptoLibJWKWritePEMError, [E.Message]);
+  end;
+end;
+
 { TJOSECryptoLibProviders }
 
 class procedure TJOSECryptoLibProviders.Register;
@@ -730,11 +1032,8 @@ begin
   TJOSEProviders.Certificate := LCert;
   TJOSEProviders.RSA := TCryptoLibRSAProvider.Create(LCert);
   TJOSEProviders.ECDSA := TCryptoLibECDSAProvider.Create(LCert);
-  // No CryptoLib-backed raw key import/export (JWK PEM support) yet: clear these rather than
-  // leaving a stale OpenSSL-backed provider active, so JWK.FromPEM/ToPEM honestly raise
-  // "not registered" instead of silently depending on OpenSSL under a CryptoLib-only stack.
-  TJOSEProviders.RSAKeyMaterial := nil;
-  TJOSEProviders.ECKeyMaterial := nil;
+  TJOSEProviders.RSAKeyMaterial := TCryptoLibRSAKeyMaterialProvider.Create;
+  TJOSEProviders.ECKeyMaterial := TCryptoLibECKeyMaterialProvider.Create;
 end;
 
 class procedure TJOSECryptoLibProviders.Unregister;

--- a/Source/Common/JOSE.Providers.Default.pas
+++ b/Source/Common/JOSE.Providers.Default.pas
@@ -870,6 +870,28 @@ begin
     JoseSSL.BN_bn2bin(ABN, @Result[0]);
 end;
 
+/// <summary>
+///   <c>BignumToBytes</c> left-padded to <paramref name="ALength" /> bytes. EC key components are
+///   fixed-width octet strings - the coordinate size of the curve for x/y (RFC 7518 6.2.1.2) and
+///   the order size for d (RFC 7518 6.2.2.1) - but <c>BN_bn2bin</c> emits the minimal encoding, so
+///   a component with a leading zero byte would otherwise come out short. Short components are not
+///   just non-conformant on the wire: they also change the canonical JSON that the RFC 7638
+///   thumbprint is computed over.
+/// </summary>
+function BignumToFixedBytes(ABN: PBIGNUM; ALength: Integer): TBytes;
+var
+  LRaw: TBytes;
+begin
+  LRaw := BignumToBytes(ABN);
+  if Length(LRaw) >= ALength then
+    Exit(LRaw);
+
+  SetLength(Result, ALength);
+  FillChar(Result[0], ALength, 0);
+  if Length(LRaw) > 0 then
+    Move(LRaw[0], Result[ALength - Length(LRaw)], Length(LRaw));
+end;
+
 function BytesToBignum(const AValue: TBytes): PBIGNUM;
 begin
   if Length(AValue) = 0 then
@@ -953,6 +975,11 @@ end;
 
 function RSAKeyToMaterial(ARsa: PRSA): TJOSERSAKeyMaterial;
 begin
+  // The result is written straight into the caller's variable, so the private components have to be
+  // cleared rather than left over from whatever that variable held before: importing a public key
+  // into a reused record would otherwise report IsPrivate and carry the previous key's secrets.
+  Result := Default(TJOSERSAKeyMaterial);
+
   Result.Modulus := BignumToBytes(ARsa.n);
   Result.PublicExponent := BignumToBytes(ARsa.e);
   if Assigned(ARsa.d) then
@@ -972,7 +999,11 @@ var
   LPoint: PEC_POINT;
   LPriv, LX, LY: PBIGNUM;
   LCtx: PBN_CTX;
+  LComponentLen: Integer;
 begin
+  // See RSAKeyToMaterial: clear before filling, so a reused record cannot keep a previous key's D.
+  Result := Default(TJOSEECKeyMaterial);
+
   Result.Curve := ACurve;
 
   LGroup := JoseSSL.EC_KEY_get0_group(AEC);
@@ -983,14 +1014,18 @@ begin
   if not Assigned(LPoint) then
     raise ESignException.Create(SJOSEJWKECNoPublicPoint);
 
+  // For every curve JOSE supports (P-256/P-384/P-521/secp256k1) the group order is the same width
+  // as a coordinate, so the field degree sizes x, y and d alike.
+  LComponentLen := (JoseSSL.EC_GROUP_get_degree(LGroup) + 7) div 8;
+
   LX := JoseSSL.BN_new();
   LY := JoseSSL.BN_new();
   LCtx := JoseSSL.BN_CTX_new();
   try
     if JoseSSL.EC_POINT_get_affine_coordinates_GFp(LGroup, LPoint, LX, LY, LCtx) <> 1 then
       raise ESignException.Create(SJOSEJWKECReadPublicPointError);
-    Result.X := BignumToBytes(LX);
-    Result.Y := BignumToBytes(LY);
+    Result.X := BignumToFixedBytes(LX, LComponentLen);
+    Result.Y := BignumToFixedBytes(LY, LComponentLen);
   finally
     JoseSSL.BN_free(LX);
     JoseSSL.BN_free(LY);
@@ -999,7 +1034,7 @@ begin
 
   LPriv := JoseSSL.EC_KEY_get0_private_key(AEC);
   if Assigned(LPriv) then
-    Result.D := BignumToBytes(LPriv);
+    Result.D := BignumToFixedBytes(LPriv, LComponentLen);
 end;
 
 function BuildECKey(const AKeyMaterial: TJOSEECKeyMaterial; ANID: Integer; AIncludePrivate: Boolean): PEC_KEY;

--- a/Tests/Source/JOSE.Tests.CryptoLib.pas
+++ b/Tests/Source/JOSE.Tests.CryptoLib.pas
@@ -31,8 +31,10 @@ uses
   JOSE.Core.JWT,
   JOSE.Core.JWS,
   JOSE.Core.JWA,
+  JOSE.Core.JWK,
   JOSE.Signing.RSA,
   JOSE.Signing.ECDSA,
+  JOSE.Signing.Base,
   JOSE.Providers,
   JOSE.Providers.CryptoLib,
   JOSE.Hashing.HMAC,
@@ -40,6 +42,12 @@ uses
   JOSE.Encoding.Base64;
 
 type
+  /// <summary>
+  ///   Tests for the CryptoLib4Pascal-backed provider stack: signing/HMAC through
+  ///   TJOSECryptoLibProviders, the TCryptoLibRSAKeyMaterialProvider/TCryptoLibECKeyMaterialProvider
+  ///   raw key import/export, the JWK PEM support those two enable, and their interoperability with
+  ///   the OpenSSL-backed default stack.
+  /// </summary>
   [TestFixture]
   [Category('CryptoLib')]
   TTestCryptoLibProviders = class(TTestBase)
@@ -48,19 +56,106 @@ type
     procedure Setup;
     [TearDown]
     procedure TearDown;
+
     [Test]
     procedure TestHMAC_SHA256_Vector;
     [Test]
     procedure TestRSA_RS256_SignVerifyRoundTrip;
     [Test]
     procedure TestECDSA_Verify_ES256_Token;
+
+    [Test]
+    procedure TestCryptoLib_RSAKeyMaterial_Registered;
+    [Test]
+    procedure TestCryptoLib_ECKeyMaterial_Registered;
+
+    [Test]
+    procedure TestRSAKeyMaterial_ImportPEM_ExtractsComponents;
+    [Test]
+    procedure TestRSAKeyMaterial_ExportPEM_RoundTrips;
+    [Test]
+    procedure TestRSAKeyMaterial_ExportPEM_PublicOnly;
+    [Test]
+    procedure TestRSAKeyMaterial_RejectsECPem;
+    [Test]
+    procedure TestRSAKeyMaterial_RejectsCertificatePem;
+
+    [Test]
+    [TestCase('P256', 'es256,P256,32')]
+    [TestCase('secp256k1', 'es256k,secp256k1,32')]
+    [TestCase('P384', 'es384,P384,48')]
+    [TestCase('P521', 'es512,P521,66')]
+    procedure TestECKeyMaterial_ImportPEM_ExtractsComponents(const AKeyFilePrefix: string; ACurve: TECCurve;
+      AComponentLen: Integer);
+
+    [Test]
+    [TestCase('P256', 'es256,P256')]
+    [TestCase('secp256k1', 'es256k,secp256k1')]
+    [TestCase('P384', 'es384,P384')]
+    [TestCase('P521', 'es512,P521')]
+    procedure TestECKeyMaterial_ExportPEM_RoundTrips(const AKeyFilePrefix: string; ACurve: TECCurve);
+
+    [Test]
+    [TestCase('P256', 'es256,P256')]
+    [TestCase('secp256k1', 'es256k,secp256k1')]
+    [TestCase('P384', 'es384,P384')]
+    [TestCase('P521', 'es512,P521')]
+    procedure TestECKeyMaterial_ExportPEM_PublicOnly(const AKeyFilePrefix: string; ACurve: TECCurve);
+
+    [Test]
+    procedure TestECKeyMaterial_RejectsRSAPem;
+
+    // JWK-level round-trips: the whole point of registering the two key-material slots.
+    [Test]
+    procedure TestJWK_RSA_FromPEM_ToPEM_SignVerify;
+
+    [Test]
+    [TestCase('ES256', 'ES256,es256,P256')]
+    [TestCase('ES256K', 'ES256K,es256k,secp256k1')]
+    [TestCase('ES384', 'ES384,es384,P384')]
+    [TestCase('ES512', 'ES512,es512,P521')]
+    procedure TestJWK_EC_FromPEM_ToPEM_SignVerify(AAlg: TJOSEAlgorithmId; const AKeyFilePrefix: string;
+      ACurve: TJOSEEllipticCurve);
+
+    // Cross-stack: the two stacks must agree on the components a PEM decodes to, and each must be
+    // able to read what the other writes.
+    [Test]
+    procedure TestInterop_RSA_ImportAgreesWithDefaultStack;
+    [Test]
+    [TestCase('P256', 'es256')]
+    [TestCase('secp256k1', 'es256k')]
+    [TestCase('P384', 'es384')]
+    [TestCase('P521', 'es512')]
+    procedure TestInterop_EC_ImportAgreesWithDefaultStack(const AKeyFilePrefix: string);
+
+    [Test]
+    procedure TestInterop_RSA_CryptoLibExport_ReadByDefaultStack;
+    [Test]
+    [TestCase('P256', 'es256')]
+    [TestCase('secp256k1', 'es256k')]
+    [TestCase('P384', 'es384')]
+    [TestCase('P521', 'es512')]
+    procedure TestInterop_EC_CryptoLibExport_ReadByDefaultStack(const AKeyFilePrefix: string);
+
+    [Test]
+    procedure TestInterop_RSA_DefaultExport_ReadByCryptoLib;
+    [Test]
+    [TestCase('P256', 'es256')]
+    [TestCase('secp256k1', 'es256k')]
+    [TestCase('P384', 'es384')]
+    [TestCase('P521', 'es512')]
+    procedure TestInterop_EC_DefaultExport_ReadByCryptoLib(const AKeyFilePrefix: string);
   end;
 
 implementation
 
 uses
   System.SysUtils,
-  System.IOUtils;
+  System.IOUtils,
+  JOSE.Types.Bytes,
+  JOSE.Core.Builder,
+  JOSE.Providers.Interfaces,
+  JOSE.Providers.Default;
 
 procedure TTestCryptoLibProviders.Setup;
 begin
@@ -120,6 +215,407 @@ begin
   finally
     LToken.Free;
   end;
+end;
+
+procedure TTestCryptoLibProviders.TestCryptoLib_RSAKeyMaterial_Registered;
+begin
+  Assert.IsNotNull(TJOSEProviders.RSAKeyMaterial, 'RSAKeyMaterial should be registered by the CryptoLib provider stack');
+end;
+
+procedure TTestCryptoLibProviders.TestCryptoLib_ECKeyMaterial_Registered;
+begin
+  Assert.IsNotNull(TJOSEProviders.ECKeyMaterial, 'ECKeyMaterial should be registered by the CryptoLib provider stack');
+end;
+
+procedure TTestCryptoLibProviders.TestRSAKeyMaterial_ImportPEM_ExtractsComponents;
+var
+  LPem: TBytes;
+  LMaterial: TJOSERSAKeyMaterial;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, 'rsa-private.pem'));
+  LMaterial := TJOSEProviders.RSAKeyMaterial.ImportPEM(LPem);
+
+  Assert.IsTrue(Length(LMaterial.Modulus) > 0, 'Modulus should not be empty');
+  Assert.IsTrue(Length(LMaterial.PublicExponent) > 0, 'PublicExponent should not be empty');
+  Assert.IsTrue(LMaterial.IsPrivate, 'Imported key should be reported as private');
+  Assert.IsTrue(Length(LMaterial.PrivateExponent) > 0, 'PrivateExponent should not be empty');
+  Assert.IsTrue(Length(LMaterial.P) > 0, 'P should not be empty');
+  Assert.IsTrue(Length(LMaterial.Q) > 0, 'Q should not be empty');
+  Assert.IsTrue(Length(LMaterial.DP) > 0, 'DP should not be empty');
+  Assert.IsTrue(Length(LMaterial.DQ) > 0, 'DQ should not be empty');
+  Assert.IsTrue(Length(LMaterial.QI) > 0, 'QI should not be empty');
+end;
+
+procedure TTestCryptoLibProviders.TestRSAKeyMaterial_ExportPEM_RoundTrips;
+var
+  LPem, LExportedPem: TBytes;
+  LMaterial, LReimported: TJOSERSAKeyMaterial;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, 'rsa-private.pem'));
+  LMaterial := TJOSEProviders.RSAKeyMaterial.ImportPEM(LPem);
+
+  LExportedPem := TJOSEProviders.RSAKeyMaterial.ExportPEM(LMaterial, True);
+  LReimported := TJOSEProviders.RSAKeyMaterial.ImportPEM(LExportedPem);
+
+  Assert.IsTrue(LReimported.IsPrivate, 'Re-imported key should still be private');
+  Assert.AreEqual<Byte>(LMaterial.Modulus, LReimported.Modulus, 'Modulus should round-trip exactly');
+  Assert.AreEqual<Byte>(LMaterial.PublicExponent, LReimported.PublicExponent, 'PublicExponent should round-trip exactly');
+  Assert.AreEqual<Byte>(LMaterial.PrivateExponent, LReimported.PrivateExponent, 'PrivateExponent should round-trip exactly');
+  Assert.AreEqual<Byte>(LMaterial.P, LReimported.P, 'P should round-trip exactly');
+  Assert.AreEqual<Byte>(LMaterial.Q, LReimported.Q, 'Q should round-trip exactly');
+  Assert.AreEqual<Byte>(LMaterial.DP, LReimported.DP, 'DP should round-trip exactly');
+  Assert.AreEqual<Byte>(LMaterial.DQ, LReimported.DQ, 'DQ should round-trip exactly');
+  Assert.AreEqual<Byte>(LMaterial.QI, LReimported.QI, 'QI should round-trip exactly');
+end;
+
+procedure TTestCryptoLibProviders.TestRSAKeyMaterial_ExportPEM_PublicOnly;
+var
+  LPem, LExportedPem: TBytes;
+  LMaterial, LReimported: TJOSERSAKeyMaterial;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, 'rsa-private.pem'));
+  LMaterial := TJOSEProviders.RSAKeyMaterial.ImportPEM(LPem);
+
+  LExportedPem := TJOSEProviders.RSAKeyMaterial.ExportPEM(LMaterial, False);
+  LReimported := TJOSEProviders.RSAKeyMaterial.ImportPEM(LExportedPem);
+
+  Assert.IsFalse(LReimported.IsPrivate, 'Public-only export should re-import as public-only');
+  Assert.AreEqual<Byte>(LMaterial.Modulus, LReimported.Modulus, 'Modulus should round-trip exactly');
+  Assert.AreEqual<Byte>(LMaterial.PublicExponent, LReimported.PublicExponent, 'PublicExponent should round-trip exactly');
+end;
+
+procedure TTestCryptoLibProviders.TestRSAKeyMaterial_RejectsECPem;
+var
+  LPem: TBytes;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, 'es256-private.pem'));
+
+  Assert.WillRaise(
+    procedure
+    begin
+      TJOSEProviders.RSAKeyMaterial.ImportPEM(LPem);
+    end,
+    ESignException
+  );
+end;
+
+procedure TTestCryptoLibProviders.TestRSAKeyMaterial_RejectsCertificatePem;
+var
+  LPem: TBytes;
+begin
+  // A certificate carries a public key, but the key-material providers take key PEMs only -
+  // extracting from a certificate is IJOSECertificateProvider's job.
+  LPem := TFile.ReadAllBytes(TPath.Combine(TPath.Combine(FKeysPath, 'cert'), 'rsa-x509.pem'));
+
+  Assert.WillRaise(
+    procedure
+    begin
+      TJOSEProviders.RSAKeyMaterial.ImportPEM(LPem);
+    end,
+    ESignException
+  );
+end;
+
+procedure TTestCryptoLibProviders.TestECKeyMaterial_ImportPEM_ExtractsComponents(const AKeyFilePrefix: string;
+  ACurve: TECCurve; AComponentLen: Integer);
+var
+  LPem: TBytes;
+  LMaterial: TJOSEECKeyMaterial;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, AKeyFilePrefix + '-private.pem'));
+  LMaterial := TJOSEProviders.ECKeyMaterial.ImportPEM(LPem);
+
+  Assert.AreEqual(ACurve, LMaterial.Curve);
+  Assert.IsTrue(LMaterial.IsPrivate, 'Imported key should be reported as private');
+
+  // RFC 7518 6.2.1.2/6.2.2.1: x, y and d are fixed-width for the curve, not minimally encoded.
+  Assert.AreEqual<Integer>(AComponentLen, Length(LMaterial.X), 'X should be the full coordinate width');
+  Assert.AreEqual<Integer>(AComponentLen, Length(LMaterial.Y), 'Y should be the full coordinate width');
+  Assert.AreEqual<Integer>(AComponentLen, Length(LMaterial.D), 'D should be the full order width');
+end;
+
+procedure TTestCryptoLibProviders.TestECKeyMaterial_ExportPEM_RoundTrips(const AKeyFilePrefix: string;
+  ACurve: TECCurve);
+var
+  LPem, LExportedPem: TBytes;
+  LMaterial, LReimported: TJOSEECKeyMaterial;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, AKeyFilePrefix + '-private.pem'));
+  LMaterial := TJOSEProviders.ECKeyMaterial.ImportPEM(LPem);
+
+  LExportedPem := TJOSEProviders.ECKeyMaterial.ExportPEM(LMaterial, True);
+  LReimported := TJOSEProviders.ECKeyMaterial.ImportPEM(LExportedPem);
+
+  Assert.AreEqual(ACurve, LReimported.Curve);
+  Assert.IsTrue(LReimported.IsPrivate, 'Re-imported key should still be private');
+  Assert.AreEqual<Byte>(LMaterial.X, LReimported.X, 'X should round-trip exactly');
+  Assert.AreEqual<Byte>(LMaterial.Y, LReimported.Y, 'Y should round-trip exactly');
+  Assert.AreEqual<Byte>(LMaterial.D, LReimported.D, 'D should round-trip exactly');
+end;
+
+procedure TTestCryptoLibProviders.TestECKeyMaterial_ExportPEM_PublicOnly(const AKeyFilePrefix: string;
+  ACurve: TECCurve);
+var
+  LPem, LExportedPem: TBytes;
+  LMaterial, LReimported: TJOSEECKeyMaterial;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, AKeyFilePrefix + '-private.pem'));
+  LMaterial := TJOSEProviders.ECKeyMaterial.ImportPEM(LPem);
+
+  LExportedPem := TJOSEProviders.ECKeyMaterial.ExportPEM(LMaterial, False);
+  LReimported := TJOSEProviders.ECKeyMaterial.ImportPEM(LExportedPem);
+
+  Assert.AreEqual(ACurve, LReimported.Curve);
+  Assert.IsFalse(LReimported.IsPrivate, 'Public-only export should re-import as public-only');
+  Assert.AreEqual<Byte>(LMaterial.X, LReimported.X, 'X should round-trip exactly');
+  Assert.AreEqual<Byte>(LMaterial.Y, LReimported.Y, 'Y should round-trip exactly');
+end;
+
+procedure TTestCryptoLibProviders.TestECKeyMaterial_RejectsRSAPem;
+var
+  LPem: TBytes;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, 'rsa-private.pem'));
+
+  Assert.WillRaise(
+    procedure
+    begin
+      TJOSEProviders.ECKeyMaterial.ImportPEM(LPem);
+    end,
+    ESignException
+  );
+end;
+
+procedure TTestCryptoLibProviders.TestJWK_RSA_FromPEM_ToPEM_SignVerify;
+var
+  LPem: TBytes;
+  LJWK: TJSONWebKey;
+  LKeyPair: TKeyPair;
+  LToken, LVerified: TJWT;
+  LCompact: TJOSEBytes;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, 'rsa-private.pem'));
+
+  LJWK := TJSONWebKey.FromPEM(LPem);
+  try
+    Assert.AreEqual(TJOSEKeyType.RSA, LJWK.Kty);
+    Assert.IsTrue(LJWK.IsPrivate);
+
+    LKeyPair := LJWK.ToKeyPair;
+    try
+      LToken := TJWT.Create;
+      try
+        LToken.Claims.Subject := 'cryptolib-jwk-rsa';
+        LCompact := TJOSE.SerializeCompact(LKeyPair.PrivateKey, TJOSEAlgorithmId.RS256, LToken);
+      finally
+        LToken.Free;
+      end;
+
+      LVerified := TJOSE.Verify(LKeyPair.PublicKey, LCompact);
+      try
+        Assert.AreEqual('cryptolib-jwk-rsa', LVerified.Claims.Subject);
+      finally
+        LVerified.Free;
+      end;
+    finally
+      LKeyPair.Free;
+    end;
+  finally
+    LJWK.Free;
+  end;
+end;
+
+procedure TTestCryptoLibProviders.TestJWK_EC_FromPEM_ToPEM_SignVerify(AAlg: TJOSEAlgorithmId;
+  const AKeyFilePrefix: string; ACurve: TJOSEEllipticCurve);
+var
+  LPem: TBytes;
+  LJWK: TJSONWebKey;
+  LKeyPair: TKeyPair;
+  LToken, LVerified: TJWT;
+  LCompact: TJOSEBytes;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, AKeyFilePrefix + '-private.pem'));
+
+  LJWK := TJSONWebKey.FromPEM(LPem);
+  try
+    Assert.AreEqual(TJOSEKeyType.EC, LJWK.Kty);
+    Assert.AreEqual(ACurve, LJWK.Crv);
+    Assert.IsTrue(LJWK.IsPrivate);
+
+    LKeyPair := LJWK.ToKeyPair;
+    try
+      LToken := TJWT.Create;
+      try
+        LToken.Claims.Subject := 'cryptolib-jwk-ec';
+        LCompact := TJOSE.SerializeCompact(LKeyPair.PrivateKey, AAlg, LToken);
+      finally
+        LToken.Free;
+      end;
+
+      LVerified := TJOSE.Verify(LKeyPair.PublicKey, LCompact);
+      try
+        Assert.AreEqual('cryptolib-jwk-ec', LVerified.Claims.Subject);
+      finally
+        LVerified.Free;
+      end;
+    finally
+      LKeyPair.Free;
+    end;
+  finally
+    LJWK.Free;
+  end;
+end;
+
+procedure TTestCryptoLibProviders.TestInterop_RSA_ImportAgreesWithDefaultStack;
+var
+  LPem: TBytes;
+  LDefault: IJOSERSAKeyMaterialProvider;
+  LFromCryptoLib, LFromDefault: TJOSERSAKeyMaterial;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, 'rsa-private.pem'));
+  LDefault := TDefaultRSAKeyMaterialProvider.Create;
+
+  LFromCryptoLib := TJOSEProviders.RSAKeyMaterial.ImportPEM(LPem);
+  LFromDefault := LDefault.ImportPEM(LPem);
+
+  Assert.AreEqual<Byte>(LFromDefault.Modulus, LFromCryptoLib.Modulus, 'Modulus should match the default stack');
+  Assert.AreEqual<Byte>(LFromDefault.PublicExponent, LFromCryptoLib.PublicExponent, 'PublicExponent should match the default stack');
+  Assert.AreEqual<Byte>(LFromDefault.PrivateExponent, LFromCryptoLib.PrivateExponent, 'PrivateExponent should match the default stack');
+  Assert.AreEqual<Byte>(LFromDefault.P, LFromCryptoLib.P, 'P should match the default stack');
+  Assert.AreEqual<Byte>(LFromDefault.Q, LFromCryptoLib.Q, 'Q should match the default stack');
+  Assert.AreEqual<Byte>(LFromDefault.DP, LFromCryptoLib.DP, 'DP should match the default stack');
+  Assert.AreEqual<Byte>(LFromDefault.DQ, LFromCryptoLib.DQ, 'DQ should match the default stack');
+  Assert.AreEqual<Byte>(LFromDefault.QI, LFromCryptoLib.QI, 'QI should match the default stack');
+end;
+
+procedure TTestCryptoLibProviders.TestInterop_EC_ImportAgreesWithDefaultStack(const AKeyFilePrefix: string);
+var
+  LPem: TBytes;
+  LDefault: IJOSEECKeyMaterialProvider;
+  LFromCryptoLib, LFromDefault: TJOSEECKeyMaterial;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, AKeyFilePrefix + '-private.pem'));
+  LDefault := TDefaultECKeyMaterialProvider.Create;
+
+  LFromCryptoLib := TJOSEProviders.ECKeyMaterial.ImportPEM(LPem);
+  LFromDefault := LDefault.ImportPEM(LPem);
+
+  Assert.AreEqual(LFromDefault.Curve, LFromCryptoLib.Curve, 'Curve should match the default stack');
+  Assert.AreEqual<Byte>(LFromDefault.X, LFromCryptoLib.X, 'X should match the default stack');
+  Assert.AreEqual<Byte>(LFromDefault.Y, LFromCryptoLib.Y, 'Y should match the default stack');
+  Assert.AreEqual<Byte>(LFromDefault.D, LFromCryptoLib.D, 'D should match the default stack');
+end;
+
+procedure TTestCryptoLibProviders.TestInterop_RSA_CryptoLibExport_ReadByDefaultStack;
+var
+  LPem, LExportedPem: TBytes;
+  LDefault: IJOSERSAKeyMaterialProvider;
+  LMaterial, LReimported: TJOSERSAKeyMaterial;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, 'rsa-private.pem'));
+  LDefault := TDefaultRSAKeyMaterialProvider.Create;
+
+  LMaterial := TJOSEProviders.RSAKeyMaterial.ImportPEM(LPem);
+  LExportedPem := TJOSEProviders.RSAKeyMaterial.ExportPEM(LMaterial, True);
+  LReimported := LDefault.ImportPEM(LExportedPem);
+
+  Assert.IsTrue(LReimported.IsPrivate, 'The default stack should read the CryptoLib private key PEM');
+  Assert.AreEqual<Byte>(LMaterial.Modulus, LReimported.Modulus, 'Modulus should survive the crossing');
+  Assert.AreEqual<Byte>(LMaterial.PrivateExponent, LReimported.PrivateExponent, 'PrivateExponent should survive the crossing');
+
+  LExportedPem := TJOSEProviders.RSAKeyMaterial.ExportPEM(LMaterial, False);
+  LReimported := LDefault.ImportPEM(LExportedPem);
+
+  Assert.IsFalse(LReimported.IsPrivate, 'The default stack should read the CryptoLib public key PEM');
+  Assert.AreEqual<Byte>(LMaterial.Modulus, LReimported.Modulus, 'Modulus should survive the crossing');
+  Assert.AreEqual<Byte>(LMaterial.PublicExponent, LReimported.PublicExponent, 'PublicExponent should survive the crossing');
+end;
+
+procedure TTestCryptoLibProviders.TestInterop_EC_CryptoLibExport_ReadByDefaultStack(const AKeyFilePrefix: string);
+var
+  LPem, LExportedPem: TBytes;
+  LDefault: IJOSEECKeyMaterialProvider;
+  LMaterial, LReimported: TJOSEECKeyMaterial;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, AKeyFilePrefix + '-private.pem'));
+  LDefault := TDefaultECKeyMaterialProvider.Create;
+
+  LMaterial := TJOSEProviders.ECKeyMaterial.ImportPEM(LPem);
+  LExportedPem := TJOSEProviders.ECKeyMaterial.ExportPEM(LMaterial, True);
+  LReimported := LDefault.ImportPEM(LExportedPem);
+
+  Assert.AreEqual(LMaterial.Curve, LReimported.Curve, 'Curve should survive the crossing');
+  Assert.IsTrue(LReimported.IsPrivate, 'The default stack should read the CryptoLib private key PEM');
+  Assert.AreEqual<Byte>(LMaterial.X, LReimported.X, 'X should survive the crossing');
+  Assert.AreEqual<Byte>(LMaterial.Y, LReimported.Y, 'Y should survive the crossing');
+  Assert.AreEqual<Byte>(LMaterial.D, LReimported.D, 'D should survive the crossing');
+
+  LExportedPem := TJOSEProviders.ECKeyMaterial.ExportPEM(LMaterial, False);
+  LReimported := LDefault.ImportPEM(LExportedPem);
+
+  Assert.AreEqual(LMaterial.Curve, LReimported.Curve, 'Curve should survive the crossing');
+  Assert.IsFalse(LReimported.IsPrivate, 'The default stack should read the CryptoLib public key PEM');
+  Assert.AreEqual<Byte>(LMaterial.X, LReimported.X, 'X should survive the crossing');
+  Assert.AreEqual<Byte>(LMaterial.Y, LReimported.Y, 'Y should survive the crossing');
+end;
+
+procedure TTestCryptoLibProviders.TestInterop_RSA_DefaultExport_ReadByCryptoLib;
+var
+  LPem, LExportedPem: TBytes;
+  LDefault: IJOSERSAKeyMaterialProvider;
+  LMaterial, LReimported: TJOSERSAKeyMaterial;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, 'rsa-private.pem'));
+  LDefault := TDefaultRSAKeyMaterialProvider.Create;
+
+  LMaterial := LDefault.ImportPEM(LPem);
+  LExportedPem := LDefault.ExportPEM(LMaterial, True);
+  LReimported := TJOSEProviders.RSAKeyMaterial.ImportPEM(LExportedPem);
+
+  Assert.IsTrue(LReimported.IsPrivate, 'CryptoLib should read the default stack private key PEM');
+  Assert.AreEqual<Byte>(LMaterial.Modulus, LReimported.Modulus, 'Modulus should survive the crossing');
+  Assert.AreEqual<Byte>(LMaterial.PrivateExponent, LReimported.PrivateExponent, 'PrivateExponent should survive the crossing');
+
+  // The default stack writes public RSA keys as PKCS#1 'RSA PUBLIC KEY', CryptoLib as SPKI
+  // 'PUBLIC KEY' - each reader has to accept both.
+  LExportedPem := LDefault.ExportPEM(LMaterial, False);
+  LReimported := TJOSEProviders.RSAKeyMaterial.ImportPEM(LExportedPem);
+
+  Assert.IsFalse(LReimported.IsPrivate, 'CryptoLib should read the default stack public key PEM');
+  Assert.AreEqual<Byte>(LMaterial.Modulus, LReimported.Modulus, 'Modulus should survive the crossing');
+  Assert.AreEqual<Byte>(LMaterial.PublicExponent, LReimported.PublicExponent, 'PublicExponent should survive the crossing');
+end;
+
+procedure TTestCryptoLibProviders.TestInterop_EC_DefaultExport_ReadByCryptoLib(const AKeyFilePrefix: string);
+var
+  LPem, LExportedPem: TBytes;
+  LDefault: IJOSEECKeyMaterialProvider;
+  LMaterial, LReimported: TJOSEECKeyMaterial;
+begin
+  LPem := TFile.ReadAllBytes(TPath.Combine(FKeysPath, AKeyFilePrefix + '-private.pem'));
+  LDefault := TDefaultECKeyMaterialProvider.Create;
+
+  LMaterial := LDefault.ImportPEM(LPem);
+
+  // The default stack writes EC private keys as PKCS#8 'PRIVATE KEY', CryptoLib as SEC1
+  // 'EC PRIVATE KEY'; a PKCS#8 EC key decodes to a lone private key, so CryptoLib has to recover
+  // the public point from the scalar to fill in x/y.
+  LExportedPem := LDefault.ExportPEM(LMaterial, True);
+  LReimported := TJOSEProviders.ECKeyMaterial.ImportPEM(LExportedPem);
+
+  Assert.AreEqual(LMaterial.Curve, LReimported.Curve, 'Curve should survive the crossing');
+  Assert.IsTrue(LReimported.IsPrivate, 'CryptoLib should read the default stack private key PEM');
+  Assert.AreEqual<Byte>(LMaterial.X, LReimported.X, 'X should survive the crossing');
+  Assert.AreEqual<Byte>(LMaterial.Y, LReimported.Y, 'Y should survive the crossing');
+  Assert.AreEqual<Byte>(LMaterial.D, LReimported.D, 'D should survive the crossing');
+
+  LExportedPem := LDefault.ExportPEM(LMaterial, False);
+  LReimported := TJOSEProviders.ECKeyMaterial.ImportPEM(LExportedPem);
+
+  Assert.AreEqual(LMaterial.Curve, LReimported.Curve, 'Curve should survive the crossing');
+  Assert.IsFalse(LReimported.IsPrivate, 'CryptoLib should read the default stack public key PEM');
+  Assert.AreEqual<Byte>(LMaterial.X, LReimported.X, 'X should survive the crossing');
+  Assert.AreEqual<Byte>(LMaterial.Y, LReimported.Y, 'Y should survive the crossing');
 end;
 
 initialization

--- a/Tests/Source/JOSE.Tests.JWK.pas
+++ b/Tests/Source/JOSE.Tests.JWK.pas
@@ -220,7 +220,7 @@ begin
     LKey2.Kid := 'key-two';
     LSet.AddKey(LKey2);
 
-    Assert.AreEqual(2, LSet.Keys.Count);
+    Assert.AreEqual<Integer>(2, LSet.Keys.Count);
 
     LJson := LSet.ToJSON;
   finally
@@ -229,7 +229,7 @@ begin
 
   LParsed := TJSONWebKeySet.FromJSON(LJson);
   try
-    Assert.AreEqual(2, LParsed.Keys.Count);
+    Assert.AreEqual<Integer>(2, LParsed.Keys.Count);
 
     LFound := LParsed.FindByKid('key-one');
     Assert.IsNotNull(LFound, 'key-one should be found in the parsed JWKS');

--- a/Tests/Source/JOSE.Tests.Providers.pas
+++ b/Tests/Source/JOSE.Tests.Providers.pas
@@ -60,7 +60,7 @@ type
     procedure TestUnregistered_ECKeyMaterial_Raises;
 
     [Test]
-    procedure TestKeyMaterialProviders_IndependentFromSigningStack;
+    procedure TestKeyMaterialSlots_CanBeClearedIndependentlyOfSigningStack;
 
     [Test]
     procedure TestRSAKeyMaterial_ImportPEM_ExtractsComponents;
@@ -72,11 +72,12 @@ type
     procedure TestRSAKeyMaterial_RejectsECPem;
 
     [Test]
-    [TestCase('P256', 'es256,P256')]
-    [TestCase('secp256k1', 'es256k,secp256k1')]
-    [TestCase('P384', 'es384,P384')]
-    [TestCase('P521', 'es512,P521')]
-    procedure TestECKeyMaterial_ImportPEM_ExtractsComponents(const AKeyFilePrefix: string; ACurve: TECCurve);
+    [TestCase('P256', 'es256,P256,32')]
+    [TestCase('secp256k1', 'es256k,secp256k1,32')]
+    [TestCase('P384', 'es384,P384,48')]
+    [TestCase('P521', 'es512,P521,66')]
+    procedure TestECKeyMaterial_ImportPEM_ExtractsComponents(const AKeyFilePrefix: string; ACurve: TECCurve;
+      AComponentLen: Integer);
 
     [Test]
     [TestCase('P256', 'es256,P256')]
@@ -144,11 +145,10 @@ begin
   );
 end;
 
-procedure TTestKeyMaterialProviders.TestKeyMaterialProviders_IndependentFromSigningStack;
+procedure TTestKeyMaterialProviders.TestKeyMaterialSlots_CanBeClearedIndependentlyOfSigningStack;
 begin
-  // Simulates a provider stack that doesn't implement raw key import/export (e.g. the
-  // CryptoLib4Pascal-backed TJOSECryptoLibProviders, which explicitly clears these two
-  // slots in TJOSECryptoLibProviders.Register - see JOSE.Providers.CryptoLib.pas).
+  // Both stacks that ship with the library implement raw key import/export, but the two slots stay
+  // optional: a caller assigning providers individually can leave them unset.
   TJOSEProviders.RSAKeyMaterial := nil;
   TJOSEProviders.ECKeyMaterial := nil;
 
@@ -253,7 +253,7 @@ begin
 end;
 
 procedure TTestKeyMaterialProviders.TestECKeyMaterial_ImportPEM_ExtractsComponents(const AKeyFilePrefix: string;
-  ACurve: TECCurve);
+  ACurve: TECCurve; AComponentLen: Integer);
 var
   LPem: TBytes;
   LMaterial: TJOSEECKeyMaterial;
@@ -262,10 +262,15 @@ begin
   LMaterial := TJOSEProviders.ECKeyMaterial.ImportPEM(LPem);
 
   Assert.AreEqual(ACurve, LMaterial.Curve);
-  Assert.IsTrue(Length(LMaterial.X) > 0, 'X should not be empty');
-  Assert.IsTrue(Length(LMaterial.Y) > 0, 'Y should not be empty');
   Assert.IsTrue(LMaterial.IsPrivate, 'Imported key should be reported as private');
-  Assert.IsTrue(Length(LMaterial.D) > 0, 'D should not be empty');
+
+  // RFC 7518 §§6.2.1.2/6.2.2.1: x, y and d are encoded as fixed-length octet
+  // strings. If the big-endian value has leading zero bytes, they MUST be
+  // retained (or added as left padding) so the encoded value has the curve's
+  // required length.
+  Assert.AreEqual<Integer>(AComponentLen, Length(LMaterial.X), 'X should be the full coordinate width');
+  Assert.AreEqual<Integer>(AComponentLen, Length(LMaterial.Y), 'Y should be the full coordinate width');
+  Assert.AreEqual<Integer>(AComponentLen, Length(LMaterial.D), 'D should be the full order width');
 end;
 
 procedure TTestKeyMaterialProviders.TestECKeyMaterial_ExportPEM_RoundTrips(const AKeyFilePrefix: string;


### PR DESCRIPTION
Add TCryptoLibRSAKeyMaterialProvider/TCryptoLibECKeyMaterialProvider, the CryptoLib4Pascal implementations of IJOSERSAKeyMaterialProvider and IJOSEECKeyMaterialProvider, and wire both from TJOSECryptoLibProviders.Register instead of clearing the slots. TJSONWebKey.FromPEM/ToPEM now works on a CryptoLib-only stack, so JWK PEM import/export no longer needs OpenSSL.

Keys are read with TOpenSslPemReader (PKCS#1, PKCS#8, SEC1 and SPKI alike) and written with TOpenSslPemWriter; EC curves are carried as named-curve OIDs so the signing providers still see PublicKeyParamSet. Both stacks read what the other writes, even though the encodings differ (CryptoLib writes public RSA keys as SPKI and EC private keys as SEC1, where OpenSSL writes PKCS#1 and PKCS#8).

Two pre-existing bugs in the OpenSSL-backed provider surfaced while testing the two stacks against each other:

- ECKeyToMaterial emitted x, y and d via BN_bn2bin, which strips leading zero bytes. RFC 7518 section 6.2.1.2 requires x and y to be "the full size of a coordinate for the curve" and section 6.2.2.1 requires d to be the order-sized octet string, so roughly one component in 256 came out a byte short. Besides being non-conformant on the wire, a short x or y changes the canonical JSON that the RFC 7638 thumbprint is computed over, producing the wrong thumbprint. Components are now padded to the curve width derived from EC_GROUP_get_degree.

- RSAKeyToMaterial/ECKeyToMaterial filled the result record without clearing it first. Delphi writes the result straight into the caller's variable, so importing a public key into a record that had held a private one left the previous key's d/p/q in place and reported IsPrivate. Both now start from Default(), which is what the new CryptoLib providers do.

Tests: JOSE.Tests.CryptoLib covers the CryptoLib key-material providers, the JWK PEM round-trips they enable for RS256 and ES256/ES256K/ES384/ES512, and cross-stack interop in both directions. JOSE.Tests.Providers asserts the fixed component widths and drops a comment that described CryptoLib as a stack without key-material support. Assert.AreEqual(2, Keys.Count) in JOSE.Tests.JWK is now explicitly instantiated, since newer DUnitX dropped the non-generic overload and could no longer infer the type argument.

Closes #98

@paolo-rossi FYI